### PR TITLE
Read Nodes by FilterQuery object ids Fixes #190

### DIFF
--- a/Robot_Adapter/Read/Elements/Bar.cs
+++ b/Robot_Adapter/Read/Elements/Bar.cs
@@ -44,9 +44,9 @@ namespace BH.Adapter.Robot
         /****           Private Methods                 ****/
         /***************************************************/
 
-        private List<Bar> ReadBars(List<string> ids = null)
+        private List<Bar> ReadBars(IList ids = null)
         {
-            IRobotCollection robotBars = m_RobotApplication.Project.Structure.Bars.GetAll();
+            List<int> barIds = CheckAndGetIds(ids);
 
             List<Bar> bhomBars = new List<Bar>();
             IEnumerable<Node> bhomNodesList = ReadNodes();
@@ -59,8 +59,9 @@ namespace BH.Adapter.Robot
             HashSet<string> tags = new HashSet<string>();
 
             m_RobotApplication.Project.Structure.Bars.BeginMultiOperation();
-            if (ids == null)
+            if (barIds == null)
             {
+                IRobotCollection robotBars = m_RobotApplication.Project.Structure.Bars.GetAll();
                 for (int i = 1; i <= robotBars.Count; i++)
                 {
                     RobotBar robotBar = robotBars.Get(i);
@@ -76,11 +77,11 @@ namespace BH.Adapter.Robot
                     bhomBars.Add(bhomBar);
                 }
             }
-            else if (ids != null && ids.Count > 0)
+            else if (barIds != null && barIds.Count > 0)
             {
-                for (int i = 0; i < ids.Count; i++)
+                for (int i = 0; i < barIds.Count; i++)
                 {
-                    RobotBar robotBar = m_RobotApplication.Project.Structure.Bars.Get(System.Convert.ToInt32(ids[i])) as RobotBar;
+                    RobotBar robotBar = m_RobotApplication.Project.Structure.Bars.Get(barIds[i]) as RobotBar;
                     Bar bhomBar = BH.Engine.Robot.Convert.ToBHoMObject( robotBar, 
                                                                         bhomNodes, 
                                                                         bhomSections, 

--- a/Robot_Adapter/Read/Elements/Bar.cs
+++ b/Robot_Adapter/Read/Elements/Bar.cs
@@ -77,7 +77,7 @@ namespace BH.Adapter.Robot
                     bhomBars.Add(bhomBar);
                 }
             }
-            else if (barIds != null && barIds.Count > 0)
+            else
             {
                 for (int i = 0; i < barIds.Count; i++)
                 {

--- a/Robot_Adapter/Read/Elements/Bar.cs
+++ b/Robot_Adapter/Read/Elements/Bar.cs
@@ -59,7 +59,7 @@ namespace BH.Adapter.Robot
             HashSet<string> tags = new HashSet<string>();
 
             m_RobotApplication.Project.Structure.Bars.BeginMultiOperation();
-            if (barIds == null)
+            if (barIds == null || barIds.Count == 0)
             {
                 IRobotCollection robotBars = m_RobotApplication.Project.Structure.Bars.GetAll();
                 for (int i = 1; i <= robotBars.Count; i++)

--- a/Robot_Adapter/Read/Elements/Node.cs
+++ b/Robot_Adapter/Read/Elements/Node.cs
@@ -41,6 +41,7 @@ namespace BH.Adapter.Robot
             List<Constraint6DOF> constraints = ReadConstraints6DOF();
             Dictionary<int, HashSet<string>> nodeTags = GetTypeTags(typeof(Node));
             HashSet<string> tags = new HashSet<string>();
+
             if (nodeIds == null || nodeIds.Count == 0)
             {
                 IRobotCollection robotNodes = m_RobotApplication.Project.Structure.Nodes.GetAll();
@@ -68,6 +69,7 @@ namespace BH.Adapter.Robot
                     bhomNodes.Add(bhomNode);
                 }
             }
+
             return bhomNodes;
         }
 

--- a/Robot_Adapter/Read/Elements/Node.cs
+++ b/Robot_Adapter/Read/Elements/Node.cs
@@ -24,6 +24,7 @@ using System.Collections.Generic;
 using BH.oM.Structure.Elements;
 using RobotOM;
 using BH.oM.Structure.Properties.Constraint;
+using System.Collections;
 
 namespace BH.Adapter.Robot
 {
@@ -33,14 +34,15 @@ namespace BH.Adapter.Robot
         /****           Private Methods                 ****/
         /***************************************************/
 
-        private List<Node> ReadNodes(List<string> ids = null)
+        private List<Node> ReadNodes(IList ids = null)
         {
+            List<int> nodeIds = CheckAndGetIds(ids);
             IRobotCollection robotNodes = m_RobotApplication.Project.Structure.Nodes.GetAll();
             List<Node> bhomNodes = new List<Node>();
             List<Constraint6DOF> constraints = ReadConstraints6DOF();
             Dictionary<int, HashSet<string>> nodeTags = GetTypeTags(typeof(Node));
             HashSet<string> tags = new HashSet<string>();
-            if (ids == null)
+            if (nodeIds == null)
             {
                 for (int i = 1; i <= robotNodes.Count; i++)
                 {
@@ -53,11 +55,11 @@ namespace BH.Adapter.Robot
                     bhomNodes.Add(bhomNode);
                 }
             }
-            else if (ids != null && ids.Count > 0)
+            else if (nodeIds != null && nodeIds.Count > 0)
             {
-                for (int i = 0; i < ids.Count; i++)
+                for (int i = 0; i < nodeIds.Count; i++)
                 {
-                    RobotNode robotNode = m_RobotApplication.Project.Structure.Nodes.Get(System.Convert.ToInt32(ids[i])) as RobotNode;
+                    RobotNode robotNode = m_RobotApplication.Project.Structure.Nodes.Get(System.Convert.ToInt32(nodeIds[i])) as RobotNode;
                     Node bhomNode = BH.Engine.Robot.Convert.ToBHoMObject(robotNode);
                     bhomNode.CustomData[AdapterId] = robotNode.Number;
                     if (nodeTags != null && nodeTags.TryGetValue(robotNode.Number, out tags))

--- a/Robot_Adapter/Read/Elements/Node.cs
+++ b/Robot_Adapter/Read/Elements/Node.cs
@@ -42,7 +42,7 @@ namespace BH.Adapter.Robot
             List<Constraint6DOF> constraints = ReadConstraints6DOF();
             Dictionary<int, HashSet<string>> nodeTags = GetTypeTags(typeof(Node));
             HashSet<string> tags = new HashSet<string>();
-            if (nodeIds == null)
+            if (nodeIds == null || nodeIds.Count == 0)
             {
                 for (int i = 1; i <= robotNodes.Count; i++)
                 {

--- a/Robot_Adapter/Read/Elements/Node.cs
+++ b/Robot_Adapter/Read/Elements/Node.cs
@@ -37,13 +37,13 @@ namespace BH.Adapter.Robot
         private List<Node> ReadNodes(IList ids = null)
         {
             List<int> nodeIds = CheckAndGetIds(ids);
-            IRobotCollection robotNodes = m_RobotApplication.Project.Structure.Nodes.GetAll();
             List<Node> bhomNodes = new List<Node>();
             List<Constraint6DOF> constraints = ReadConstraints6DOF();
             Dictionary<int, HashSet<string>> nodeTags = GetTypeTags(typeof(Node));
             HashSet<string> tags = new HashSet<string>();
             if (nodeIds == null || nodeIds.Count == 0)
             {
+                IRobotCollection robotNodes = m_RobotApplication.Project.Structure.Nodes.GetAll();
                 for (int i = 1; i <= robotNodes.Count; i++)
                 {
                     RobotNode robotNode = robotNodes.Get(i);
@@ -55,7 +55,7 @@ namespace BH.Adapter.Robot
                     bhomNodes.Add(bhomNode);
                 }
             }
-            else if (nodeIds != null && nodeIds.Count > 0)
+            else
             {
                 for (int i = 0; i < nodeIds.Count; i++)
                 {

--- a/Robot_Adapter/Read/Read.cs
+++ b/Robot_Adapter/Read/Read.cs
@@ -50,7 +50,7 @@ namespace BH.Adapter.Robot
                 return ReadNodes(indices);
 
             if (type == typeof(Bar))
-                return ReadBars();
+                return ReadBars(indices);
 
             if (type == typeof(Opening))
                 return ReadOpenings();

--- a/Robot_Adapter/Read/Read.cs
+++ b/Robot_Adapter/Read/Read.cs
@@ -47,7 +47,7 @@ namespace BH.Adapter.Robot
         protected override IEnumerable<IBHoMObject> Read(Type type, IList indices = null)
         {
             if (type == typeof(Node))
-                return ReadNodes();
+                return ReadNodes(indices);
 
             if (type == typeof(Bar))
                 return ReadBars();

--- a/Robot_Adapter/Read/Results/MeshResults.cs
+++ b/Robot_Adapter/Read/Results/MeshResults.cs
@@ -80,7 +80,7 @@ namespace BH.Adapter.Robot
                         panelIds.Add(System.Convert.ToInt32(obj));
                     }
                 }
-                if (panelIds.Count > 1)
+                if (panelIds.Count > 0)
                 {
                     panels.AddRange(ReadPanels(panelIds as dynamic));
                 }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #190. This PR makes it possible to use a FilterQuery with objectIds to read nodes


 ### Test files
<!-- Link to test files to validate the proposed changes -->

[Test file](https://burohappold.sharepoint.com/:f:/s/BHoM/EpYGU-ftwYZFvDY5Xjt_pu4BdcQlX8wT6vvZ69fvlWygjw?e=5U6Q1v )

To test this issue, create the following and open robot model with node ids 1, 2, 3, 4 and 10
![image](https://user-images.githubusercontent.com/40766496/53242268-35fbc000-369c-11e9-8c36-f97cb60124e3.png)


 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->
