### PR TITLE
Robot_Toolkit: Null check and warning for material from label name

### DIFF
--- a/Robot_Adapter/Read/Properties/Material.cs
+++ b/Robot_Adapter/Read/Properties/Material.cs
@@ -80,7 +80,10 @@ namespace BH.Adapter.Robot
         private IMaterialFragment ReadMaterialByLabelName(string labelName)
         {
             IRobotLabel materialLabel = m_RobotApplication.Project.Structure.Labels.Get(IRobotLabelType.I_LT_MATERIAL, labelName);
-            return MaterialFromLabel(materialLabel);
+            if(materialLabel != null)
+                return MaterialFromLabel(materialLabel);
+
+            return null;
         }
 
         /***************************************************/

--- a/Robot_Adapter/Read/Properties/SectionProperty.cs
+++ b/Robot_Adapter/Read/Properties/SectionProperty.cs
@@ -51,6 +51,24 @@ namespace BH.Adapter.Robot
                 if (!materials.TryGetValue(secData.MaterialName, out bhomMat))
                 {
                     bhomMat = ReadMaterialByLabelName(secData.MaterialName);
+
+                    if (bhomMat == null)
+                    {
+                        string materialType = "";
+                        if (secData.IsConcrete)
+                        {
+                            bhomMat = new Concrete() { Name = secData.MaterialName };
+                            materialType = "Concrete";
+                        }
+                        else
+                        {
+                            bhomMat = new Steel() { Name = secData.MaterialName };
+                            materialType = "Steel";
+                        }
+
+                        Engine.Reflection.Compute.RecordWarning("Unable to extract material with label " + secData.MaterialName + ". An empty " + materialType + " with the same name has been created in its place");
+                    }
+
                     materials[bhomMat.Name] = bhomMat;
                 }
 

--- a/Robot_Adapter/Read/Properties/SectionProperty.cs
+++ b/Robot_Adapter/Read/Properties/SectionProperty.cs
@@ -54,6 +54,8 @@ namespace BH.Adapter.Robot
 
                     if (bhomMat == null)
                     {
+                        //TODO: find a sensible way to get out the type of material that the section in expecting.
+                        //For now resorting to checking for concrete, if not true assume steal.
                         string materialType = "";
                         if (secData.IsConcrete)
                         {


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #217 

 <!-- Add short description of what has been fixed -->
This will fix a problem sometimes occurring when robot tries to get default materials for sections in the model, but fails. The behaviour for this is quite strange, and there seem to be a difference in behaviour if the same model is opened after Robot has been started via toggling on the RobotAdapter or if it has been started manually.

- Adding nullcheck for materiallabel before trying to convert
- Setting empty Steel/Concrete when materials fail to be read out while pulling sections. When this happens a warning is also raised informing the user.

I was not able to get any sensible information about the "Section Type" as shown in the Robot dialog boxes. Only feasible check found was "IsConcrete" for now creating an empty concrete if this is true, otherwise an empty steel.

 ### Test files
<!-- Link to test files to validate the proposed changes -->

Test file from issue:
https://burohappold.sharepoint.com/:u:/s/BHoM/EUe8h521aXhApU7_knbYg88BPUoy2-XtW3Gp2vn-g1EAEg?e=mscGQ9


 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->

@johannaisak @alexradne I know both of you have had problems with this. Could you also check if this solves it for you?