### PR TITLE
Robot_Toolkit: Issue 231 - Incorrect outstands for box section convert

### DIFF
--- a/Robot_Engine/Convert/FromRobot/SectionProperty_Steel.cs
+++ b/Robot_Engine/Convert/FromRobot/SectionProperty_Steel.cs
@@ -140,6 +140,15 @@ namespace BH.Engine.Robot
                         sectionProfile = BH.Engine.Geometry.Create.ISectionProfile(H + (2 * TF), B, TW, TF, 0, 0);
                         return BH.Engine.Structure.Create.SteelSectionFromProfile(sectionProfile);
 
+                    case IRobotBarSectionShapeType.I_BSST_USER_BOX_2:
+                        B = nonStdData.GetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_BOX_2_B);
+                        B1 = nonStdData.GetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_BOX_2_B1);
+                        H = nonStdData.GetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_BOX_2_H);
+                        TW = nonStdData.GetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_BOX_2_TW);
+                        TF = nonStdData.GetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_BOX_2_TF);
+                        sectionProfile = BH.Engine.Geometry.Create.GeneralisedFabricatedBoxProfile(H + (2*TF), B1 + (2 * TW), TW, TF, TF, (B - B1 - (2 * TW)) / 2, (B - B1 - (2 * TW)) / 2);
+                        return BH.Engine.Structure.Create.SteelSectionFromProfile(sectionProfile);
+
                     case IRobotBarSectionShapeType.I_BSST_USER_BOX_3:
                         B = nonStdData.GetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_BOX_3_B);
                         B1 = nonStdData.GetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_BOX_3_B1);
@@ -148,8 +157,7 @@ namespace BH.Engine.Robot
                         TW = nonStdData.GetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_BOX_3_TW);
                         TF = nonStdData.GetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_BOX_3_TF);
                         TF2 = nonStdData.GetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_BOX_3_TF2);
-
-                        sectionProfile = BH.Engine.Geometry.Create.FabricatedBoxProfile(H + TF + TF2, B1 + (2 * TW), TW, TF2, TF, 0);
+                        sectionProfile = BH.Engine.Geometry.Create.GeneralisedFabricatedBoxProfile(H + TF + TF2, B1 + (2*TW), TW, TF, TF2, (B2 - B1 - (2*TW))/2, (B - B1 - (2 * TW))/2);
                         return BH.Engine.Structure.Create.SteelSectionFromProfile(sectionProfile);
 
                     case IRobotBarSectionShapeType.I_BSST_BOX:

--- a/Robot_Engine/Convert/FromRobot/SectionProperty_Steel.cs
+++ b/Robot_Engine/Convert/FromRobot/SectionProperty_Steel.cs
@@ -400,7 +400,7 @@ namespace BH.Engine.Robot
 
             nonStdData.SetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_BOX_3_B, section.Width + section.BotLeftCorbelWidth + section.BotRightCorbelWidth);
             nonStdData.SetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_BOX_3_B1, section.Width - (2 * section.WebThickness));
-            nonStdData.SetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_BOX_3_B2, section.Width);
+            nonStdData.SetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_BOX_3_B2, section.Width + section.TopLeftCorbelWidth + section.TopLeftCorbelWidth);
             nonStdData.SetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_BOX_3_H, section.Height - (section.TopFlangeThickness + section.BotFlangeThickness));
             nonStdData.SetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_BOX_3_TW, section.WebThickness);
             nonStdData.SetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_BOX_3_TF, section.TopFlangeThickness);


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->


 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #231 

 <!-- Add short description of what has been fixed -->


 ### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/Robot_Toolkit/Robot_Toolkit-Issue231-Incorrect%20outstands%20for%20box%20section?csf=1&e=JVJZxs

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->

![image](https://user-images.githubusercontent.com/15233608/60302589-14e9fb00-992c-11e9-8f5e-f68940cb9b8e.png)

![image](https://user-images.githubusercontent.com/15233608/60302601-1d423600-992c-11e9-9e84-815b189ee48d.png)

