### PR TITLE
TryGetValue for extracting material when pulling bars

### DIFF
--- a/Robot_Engine/Convert/FromRobot/Bar.cs
+++ b/Robot_Engine/Convert/FromRobot/Bar.cs
@@ -63,7 +63,13 @@ namespace BH.Engine.Robot
                 {
                     //Get material name and material
                     string matName = robotBar.GetLabelName(IRobotLabelType.I_LT_MATERIAL);
-                    barMaterial = bhomMaterials[matName];
+
+
+                    if (!bhomMaterials.TryGetValue(matName, out barMaterial))
+                    {
+                        BH.Engine.Reflection.Compute.RecordWarning("Could not extract material with name" + matName + "null material will be provided for the crossection for bars with this material.");
+                    }
+
 
                     Dictionary<string, ISectionProperty> innerDict;
                     //Check if a section of the specified type has allready been pulled


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #233 

 <!-- Add short description of what has been fixed -->

TreGetValue and error raising instead of just getting value from dictionary. Avoids Robot crashing for some edge cases when pulling bars.

 ### Test files
<!-- Link to test files to validate the proposed changes -->

Robotmodel:

https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/Robot_Toolkit/Robot_Toolkit-Issue233-CheckMaterialWhenPullingBars?csf=1&e=XB8FUI

Pull script (macro pull for Robot): 

https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/Robot_Toolkit/_Macro/Pull?csf=1&e=boWSD1

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->
