### PR TITLE
Robot_Toolkit: Issue244 Deleting Loadcases and Combinations

### DIFF
--- a/Robot_Adapter/Create/LoadCombination.cs
+++ b/Robot_Adapter/Create/LoadCombination.cs
@@ -34,17 +34,18 @@ namespace BH.Adapter.Robot
 
         private bool CreateCollection(IEnumerable<LoadCombination> lComabinations)
         {
-
             foreach (LoadCombination lComb in lComabinations)
             {
-                RobotCaseCombination rCaseCombination = m_RobotApplication.Project.Structure.Cases.CreateCombination(lComb.Number, lComb.Name, IRobotCombinationType.I_CBT_ULS, IRobotCaseNature.I_CN_PERMANENT, IRobotCaseAnalizeType.I_CAT_COMB);
-                for (int i = 0; i < lComb.LoadCases.Count; i++)
+                if (m_RobotApplication.Project.Structure.Cases.Exist(lComb.Number)!=-1)
                 {
-                    rCaseCombination.CaseFactors.New(lComb.LoadCases[i].Item2.Number, lComb.LoadCases[i].Item1);
+                    RobotCaseCombination rCaseCombination = m_RobotApplication.Project.Structure.Cases.CreateCombination(lComb.Number, lComb.Name, IRobotCombinationType.I_CBT_ULS, IRobotCaseNature.I_CN_PERMANENT, IRobotCaseAnalizeType.I_CAT_COMB);
+                    for (int i = 0; i < lComb.LoadCases.Count; i++)
+                    {
+                        rCaseCombination.CaseFactors.New(lComb.LoadCases[i].Item2.Number, lComb.LoadCases[i].Item1);
+                    }
+                    updateview();
                 }
-                updateview();
             }
-        
             return true;
         }
 

--- a/Robot_Adapter/Create/LoadCombination.cs
+++ b/Robot_Adapter/Create/LoadCombination.cs
@@ -45,6 +45,11 @@ namespace BH.Adapter.Robot
                     }
                     updateview();
                 }
+                else
+                {
+                    BH.Engine.Reflection.Compute.RecordWarning("Note if a combination in the model with the same number exists, combination will not be pushed. Use 'delete'" +
+                        "to clear combinations before re-pushing");
+                }
             }
             return true;
         }

--- a/Robot_Adapter/Create/_Create.cs
+++ b/Robot_Adapter/Create/_Create.cs
@@ -112,8 +112,6 @@ namespace BH.Adapter.Robot
 
                 if (objects.First() is LoadCombination)
                 {
-                    BH.Engine.Reflection.Compute.RecordWarning("Note if a combination in the model with the same number exists, combination will not be pushed. Use 'delete'" +
-                        "to clear combinations before re-pushing");
                     success = CreateCollection(objects as IEnumerable<LoadCombination>);
                 }
 

--- a/Robot_Adapter/Create/_Create.cs
+++ b/Robot_Adapter/Create/_Create.cs
@@ -29,6 +29,7 @@ using BH.oM.Structure.SurfaceProperties;
 using BH.oM.Structure.Loads;
 using BH.oM.Structure.MaterialFragments;
 using BH.oM.Adapters.Robot;
+using BH.oM.Reflection.Attributes;
 
 namespace BH.Adapter.Robot
 {
@@ -111,6 +112,8 @@ namespace BH.Adapter.Robot
 
                 if (objects.First() is LoadCombination)
                 {
+                    BH.Engine.Reflection.Compute.RecordWarning("Note if a combination in the model with the same number exists, combination will not be pushed. Use 'delete'" +
+                        "to clear combinations before re-pushing");
                     success = CreateCollection(objects as IEnumerable<LoadCombination>);
                 }
 

--- a/Robot_Adapter/Delete/_Delete.cs
+++ b/Robot_Adapter/Delete/_Delete.cs
@@ -47,6 +47,8 @@ namespace BH.Adapter.Robot
                 success = DeleteBars(ids);
             if (type == typeof(BH.oM.Structure.Loads.Loadcase)) 
                 success = DeleteLoadcases(ids);
+            if (type == typeof(BH.oM.Structure.Loads.LoadCombination))
+                success = DeleteLoadCombinations(ids);
             if (type == null)
                 success = DeleteAll();
             updateview();
@@ -153,14 +155,35 @@ namespace BH.Adapter.Robot
             }
             else
             {
-                int maxNodeIndex = m_RobotApplication.Project.Structure.Cases.FreeNumber;
-                for (int i = 1; i < maxNodeIndex; i++)
+                caseSel = m_RobotApplication.Project.Structure.Selections.CreatePredefined(IRobotPredefinedSelection.I_PS_CASE_SIMPLE_CASES);                
+            }            
+            m_RobotApplication.Project.Structure.Cases.DeleteMany(caseSel);
+            m_tags[typeof(Bar)] = caseTags;
+            return sucess;
+        }
+
+        /***************************************************/
+
+        public int DeleteLoadCombinations(IEnumerable<object> ids)
+        {
+            int sucess = 1;
+            string caseIds = "";
+            RobotSelection caseSel = m_RobotApplication.Project.Structure.Selections.Create(IRobotObjectType.I_OT_CASE);
+            Dictionary<int, HashSet<string>> caseTags = GetTypeTags(typeof(BH.oM.Structure.Loads.Loadcase));
+            if (ids != null)
+            {
+                List<int> indicies = ids.Cast<int>().ToList();
+                foreach (int ind in indicies)
                 {
-                    caseIds += i.ToString() + ",";
-                    caseTags.Remove(i);
+                    caseIds += ind.ToString() + ",";
+                    caseTags.Remove(ind);
                 }
                 caseIds.TrimEnd(',');
                 caseSel.FromText(caseIds);
+            }
+            else
+            {
+                caseSel = m_RobotApplication.Project.Structure.Selections.CreatePredefined(IRobotPredefinedSelection.I_PS_CASE_COMBINATIONS);
             }
             m_RobotApplication.Project.Structure.Cases.DeleteMany(caseSel);
             m_tags[typeof(Bar)] = caseTags;

--- a/Robot_Adapter/Delete/_Delete.cs
+++ b/Robot_Adapter/Delete/_Delete.cs
@@ -26,6 +26,7 @@ using System.Linq;
 using BH.oM.Structure.Elements;
 using RobotOM;
 using BH.oM.Structure.Design;
+using BH.Engine.Reflection;
 
 namespace BH.Adapter.Robot
 {
@@ -45,8 +46,11 @@ namespace BH.Adapter.Robot
                 success = DeleteNodes(ids);
             if (type == typeof(Bar))
                 success = DeleteBars(ids);
-            if (type == typeof(BH.oM.Structure.Loads.Loadcase)) 
+            if (type == typeof(BH.oM.Structure.Loads.Loadcase))
+            {
+                BH.Engine.Reflection.Compute.RecordWarning("Note that when all cases are deleted in Robot, combinations are deleted also");
                 success = DeleteLoadcases(ids);
+            }
             if (type == typeof(BH.oM.Structure.Loads.LoadCombination))
                 success = DeleteLoadCombinations(ids);
             if (type == null)
@@ -155,7 +159,7 @@ namespace BH.Adapter.Robot
             }
             else
             {
-                caseSel = m_RobotApplication.Project.Structure.Selections.CreatePredefined(IRobotPredefinedSelection.I_PS_CASE_SIMPLE_CASES);                
+                caseSel = m_RobotApplication.Project.Structure.Selections.CreatePredefined(IRobotPredefinedSelection.I_PS_CASE_SIMPLE_CASES);               
             }            
             m_RobotApplication.Project.Structure.Cases.DeleteMany(caseSel);
             m_tags[typeof(Bar)] = caseTags;

--- a/Robot_Adapter/Delete/_Delete.cs
+++ b/Robot_Adapter/Delete/_Delete.cs
@@ -47,10 +47,7 @@ namespace BH.Adapter.Robot
             if (type == typeof(Bar))
                 success = DeleteBars(ids);
             if (type == typeof(BH.oM.Structure.Loads.Loadcase))
-            {
-                BH.Engine.Reflection.Compute.RecordWarning("Note that when all cases are deleted in Robot, combinations are deleted also");
                 success = DeleteLoadcases(ids);
-            }
             if (type == typeof(BH.oM.Structure.Loads.LoadCombination))
                 success = DeleteLoadCombinations(ids);
             if (type == null)
@@ -163,6 +160,7 @@ namespace BH.Adapter.Robot
             }            
             m_RobotApplication.Project.Structure.Cases.DeleteMany(caseSel);
             m_tags[typeof(Bar)] = caseTags;
+            BH.Engine.Reflection.Compute.RecordWarning("Note that when all cases are deleted in Robot, combinations are deleted also");
             return sucess;
         }
 

--- a/Robot_Adapter/Delete/_Delete.cs
+++ b/Robot_Adapter/Delete/_Delete.cs
@@ -159,8 +159,8 @@ namespace BH.Adapter.Robot
                 caseSel = m_RobotApplication.Project.Structure.Selections.CreatePredefined(IRobotPredefinedSelection.I_PS_CASE_SIMPLE_CASES);               
             }            
             m_RobotApplication.Project.Structure.Cases.DeleteMany(caseSel);
-            m_tags[typeof(Bar)] = caseTags;
-            BH.Engine.Reflection.Compute.RecordWarning("Note that when all cases are deleted in Robot, combinations are deleted also");
+            m_tags[typeof(BH.oM.Structure.Loads.Loadcase)] = caseTags;
+            if(ids == null || ids.Count() != 0) BH.Engine.Reflection.Compute.RecordWarning("Note that when all cases are deleted in Robot, combinations are deleted also");
             return sucess;
         }
 
@@ -171,7 +171,7 @@ namespace BH.Adapter.Robot
             int sucess = 1;
             string caseIds = "";
             RobotSelection caseSel = m_RobotApplication.Project.Structure.Selections.Create(IRobotObjectType.I_OT_CASE);
-            Dictionary<int, HashSet<string>> caseTags = GetTypeTags(typeof(BH.oM.Structure.Loads.Loadcase));
+            Dictionary<int, HashSet<string>> caseTags = GetTypeTags(typeof(BH.oM.Structure.Loads.LoadCombination));
             if (ids != null)
             {
                 List<int> indicies = ids.Cast<int>().ToList();
@@ -188,7 +188,7 @@ namespace BH.Adapter.Robot
                 caseSel = m_RobotApplication.Project.Structure.Selections.CreatePredefined(IRobotPredefinedSelection.I_PS_CASE_COMBINATIONS);
             }
             m_RobotApplication.Project.Structure.Cases.DeleteMany(caseSel);
-            m_tags[typeof(Bar)] = caseTags;
+            m_tags[typeof(BH.oM.Structure.Loads.LoadCombination)] = caseTags;
             return sucess;
         }
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #244 

 <!-- Add short description of what has been fixed -->
The adapter previously deleted load combinations as well as cases when delete set to 'loadcase' object type. Also, when pushing combinations, if the combination in Robot existed (same number) additional load factors were injected - could cause users to double up on factors if not well checked. 

 ### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/Robot_Toolkit/Robot_Toolkit-Issue244-Deleting%20Loadcases?csf=1&e=ncsNOD 

To test, open a blank Robot model/file, and use the push loadcases, then combinations, and use the delete loadcases and combinations toggles to test that when combinations are deleted, cases remain. Note that if all cases for a particularly combination are deleted in Robot, the combination is also automatically deleted (this is expected Robot functionality). If combinations are pushed twice, these will no longer update, to push combinations again, first delete those in the model. 

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
 - Loadcases now able to be deleted in isolation from combinations. 
 - Combinations able to be deleted in isolation from cases. 
 - Warnings have been added to create combinations (that if the combination exists it will not be pushed) and delete loadcases (that if all cases in a combination are deleted, the combination is also deleted).

 ### Additional comments
<!-- As required -->
