### PR TITLE
Fixing node constraints with springs not being set correctly

### DIFF
--- a/Robot_Adapter/Update/UpdateObjects.cs
+++ b/Robot_Adapter/Update/UpdateObjects.cs
@@ -161,7 +161,26 @@ namespace BH.Adapter.Robot
         protected bool Update(IEnumerable<Constraint6DOF> nodeConst)
         {
             bool success = true;
-            success = Create(nodeConst);
+
+            m_RobotApplication.Interactive = 0;
+
+            try
+            {
+                foreach (Constraint6DOF constraint in nodeConst)
+                {
+                    RobotNodeSupport robotSupport = m_RobotApplication.Project.Structure.Labels.Get(IRobotLabelType.I_LT_SUPPORT, constraint.Name) as RobotNodeSupport;
+                    IRobotNodeSupportData suppData = robotSupport.Data;
+
+                    Engine.Robot.Convert.RobotConstraint(suppData, constraint);
+
+                    m_RobotApplication.Project.Structure.Labels.Store(robotSupport);
+                }
+            }
+            finally
+            {
+                m_RobotApplication.Interactive = 1;
+            }
+
             return success;
         }
 

--- a/Robot_Engine/Convert/Private Helpers/Constraint.cs
+++ b/Robot_Engine/Convert/Private Helpers/Constraint.cs
@@ -33,12 +33,12 @@ namespace BH.Engine.Robot
 
         public static void RobotConstraint(IRobotNodeSupportData suppData, Constraint6DOF constraint)
         {
-            suppData.UX = (int)(constraint.TranslationX);
-            suppData.UY = (int)(constraint.TranslationY);
-            suppData.UZ = (int)(constraint.TranslationZ);
-            suppData.RX = (int)(constraint.RotationX);
-            suppData.RY = (int)(constraint.RotationY);
-            suppData.RZ = (int)(constraint.RotationZ);
+            suppData.UX = constraint.TranslationX == DOFType.Fixed ? 1 : 0;
+            suppData.UY = constraint.TranslationY == DOFType.Fixed ? 1 : 0;
+            suppData.UZ = constraint.TranslationZ == DOFType.Fixed ? 1 : 0;
+            suppData.RX = constraint.RotationX == DOFType.Fixed ? 1 : 0;
+            suppData.RY = constraint.RotationY == DOFType.Fixed ? 1 : 0;
+            suppData.RZ = constraint.RotationZ == DOFType.Fixed ? 1 : 0;
             suppData.KX = constraint.TranslationalStiffnessX;
             suppData.KY = constraint.TranslationalStiffnessY;
             suppData.KZ = constraint.TranslationalStiffnessZ;


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #248 
Closes #249 

 <!-- Add short description of what has been fixed -->

- Making sure nodes only get fixed for fixity = `DOFType.Fixed`
- Update for the `Update` Method for Constraint6DOF to increase performance of the method.

 ### Test files
https://burohappold.sharepoint.com/:u:/s/BHoM/ERzLTvclt0ZNoOM_A9EeIsUBpNOsU2eXMaxj8SJOEcA2ew?e=RTt6ub


 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->
