### PR TITLE
Robot_Toolkit-#254-Support for read groups

### DIFF
--- a/Robot_Adapter/Read/Elements/Groups.cs
+++ b/Robot_Adapter/Read/Elements/Groups.cs
@@ -1,0 +1,75 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System.Collections.Generic;
+using RobotOM;
+using BH.oM.Structure.Elements;
+using BH.oM.Structure.Loads;
+
+namespace BH.Adapter.Robot
+{
+    public partial class RobotAdapter
+    {
+        /***************************************************/
+        /****           Private Methods                 ****/
+        /***************************************************/
+
+        private List<BH.oM.Base.IBHoMObject> ReadGroups()
+        {
+            List<BH.oM.Base.IBHoMObject> groups = new List<oM.Base.IBHoMObject>();
+            RobotGroupServer m_groupServ = m_RobotApplication.Project.Structure.Groups;
+            for (int i = 1; i <= m_groupServ.GetCount(IRobotObjectType.I_OT_BAR); i++)
+            {
+                RobotGroup rgroup = m_RobotApplication.Project.Structure.Groups.Get(IRobotObjectType.I_OT_BAR, i);
+                if (rgroup != null)
+                {
+                    List<Bar> obj = ReadBars(BH.Engine.Robot.Convert.FromRobotSelectionString(rgroup.SelList));
+                    groups.Add(BH.Engine.Base.Create.BHoMGroup(obj, false, rgroup.Name));
+                }
+            }
+            for (int i = 1; i <= m_groupServ.GetCount(IRobotObjectType.I_OT_NODE); i++)
+            {
+                RobotGroup rgroup = m_RobotApplication.Project.Structure.Groups.Get(IRobotObjectType.I_OT_NODE, i);
+                if (rgroup != null)
+                {
+                    List<Node> obj = ReadNodes(BH.Engine.Robot.Convert.FromRobotSelectionString(rgroup.SelList));
+                    groups.Add(BH.Engine.Base.Create.BHoMGroup(obj, false, rgroup.Name));
+                }
+            }
+            for (int i = 1; i <= m_groupServ.GetCount(IRobotObjectType.I_OT_PANEL); i++)
+            {
+                RobotGroup rgroup = m_RobotApplication.Project.Structure.Groups.Get(IRobotObjectType.I_OT_PANEL, i);
+                if (rgroup != null)
+                {
+                    List<Panel> obj = ReadPanels(BH.Engine.Robot.Convert.FromRobotSelectionString(rgroup.SelList));
+                    groups.Add(BH.Engine.Base.Create.BHoMGroup(obj, false, rgroup.Name));
+                }
+            }
+            return groups;
+        }
+
+        /***************************************************/
+
+    }
+
+}
+

--- a/Robot_Adapter/Read/Read.cs
+++ b/Robot_Adapter/Read/Read.cs
@@ -93,7 +93,7 @@ namespace BH.Adapter.Robot
                 return ReadLoads(); //TODO: Implement load extraction
 
             if (type.IsGenericType && type.Name == typeof(BHoMGroup<IBHoMObject>).Name)
-                return new List<BHoMGroup<IBHoMObject>>();
+                return ReadGroups();
 
             if (type == typeof(FramingElementDesignProperties))
                 return ReadFramingElementDesignProperties();

--- a/Robot_Adapter/Robot_Adapter.csproj
+++ b/Robot_Adapter/Robot_Adapter.csproj
@@ -126,6 +126,7 @@
     <Compile Include="Execute\_Execute.cs" />
     <Compile Include="Adapter\NextId.cs" />
     <Compile Include="Read\Elements\Bar.cs" />
+    <Compile Include="Read\Elements\Groups.cs" />
     <Compile Include="Read\Elements\Mesh.cs" />
     <Compile Include="Read\Elements\RigidLink.cs" />
     <Compile Include="Read\Loads\Load.cs" />


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->


 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #254 

 <!-- Add short description of what has been fixed -->
Support added for reading BHoM Groups

 ### Test files
<!-- Link to test files to validate the proposed changes -->
Robot_Toolkit-Issue254-Read support for groups

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
 - Added support for reading groups in Robot. Groups are read if a FilterRequest with Type BH.oM.Base.BHoMGroup`1 is input to a Pull. 

 ### Additional comments
<!-- As required -->
The Explode function doesn't appear to be working to explode a list of BHoMGroups as is returned by the pull. @IsakNaslundBh , @epignatelli may need to raise a separate issue on the Engine? 

![image](https://user-images.githubusercontent.com/15233608/63805170-be3f7400-c910-11e9-941b-590be8e783ca.png)
