### PR TITLE
Fix for update bars crashing for null DesignProperties

### DIFF
--- a/Robot_Adapter/Update/Bars.cs
+++ b/Robot_Adapter/Update/Bars.cs
@@ -57,9 +57,12 @@ namespace BH.Adapter.Robot
                 if (bar.CustomData.ContainsKey("FramingElementDesignProperties"))
                 {
                     FramingElementDesignProperties framEleDesProps = bar.CustomData["FramingElementDesignProperties"] as FramingElementDesignProperties;
-                    if (m_RobotApplication.Project.Structure.Labels.Exist(IRobotLabelType.I_LT_MEMBER_TYPE, framEleDesProps.Name) != -1)
-                        Create(framEleDesProps);
-                    robotBar.SetLabel(IRobotLabelType.I_LT_MEMBER_TYPE, framEleDesProps.Name);
+                    if (framEleDesProps != null)
+                    {
+                        if (m_RobotApplication.Project.Structure.Labels.Exist(IRobotLabelType.I_LT_MEMBER_TYPE, framEleDesProps.Name) != -1)
+                            Create(framEleDesProps);
+                        robotBar.SetLabel(IRobotLabelType.I_LT_MEMBER_TYPE, framEleDesProps.Name);
+                    }
                 }
 
             }


### PR DESCRIPTION


 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #259

 <!-- Add short description of what has been fixed -->
Adding null check for FramingELementDesignProperties

 ### Test files
<!-- Link to test files to validate the proposed changes -->

https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/Robot_Toolkit/Robot_Toolkit-Issue259-UpdateBarCrashFix?csf=1&e=NNai5s
