### PR TITLE
Robot_Toolkit-#261-PullSeismicCombinationModalDisplacements

### DIFF
--- a/Robot_Adapter/Read/Results/NodeDisplacement.cs
+++ b/Robot_Adapter/Read/Results/NodeDisplacement.cs
@@ -74,6 +74,9 @@ namespace BH.Adapter.Robot
 
             queryParams.Selection.Set(IRobotObjectType.I_OT_CASE, caseSelection);
             queryParams.Selection.Set(IRobotObjectType.I_OT_NODE, nodeSelection);
+            queryParams.SetParam(IRobotResultParamType.I_RPT_MODE, 0);
+            queryParams.SetParam(IRobotResultParamType.I_RPT_MODE_CMB, IRobotModeCombinationType.I_MCT_CQC);
+
             RobotResultRowSet rowSet = new RobotResultRowSet();
 
             IRobotResultQueryReturnType ret = IRobotResultQueryReturnType.I_RQRT_MORE_AVAILABLE;


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #261 

 <!-- Add short description of what has been fixed -->


 ### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/Robot_Toolkit/%20Robot_Toolkit-Issue%20261-Pull%20NodeResult%20Seismic%20Case?csf=1&e=Bx9RHs

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
 - Enabled pulling of seismic combination nodal displacements (instead of individual mode components).

