### PR TITLE
Enables costum set (local) axis when pushing loads to Robot

### DIFF
--- a/Robot_Engine/Convert/Private Helpers/Load.cs
+++ b/Robot_Engine/Convert/Private Helpers/Load.cs
@@ -146,6 +146,12 @@ namespace BH.Engine.Robot
                 loadRecordForce.SetValue((short)IRobotBarUniformRecordValues.I_BURV_PX, load.Force.X);
                 loadRecordForce.SetValue((short)IRobotBarUniformRecordValues.I_BURV_PY, load.Force.Y);
                 loadRecordForce.SetValue((short)IRobotBarUniformRecordValues.I_BURV_PZ, load.Force.Z);
+
+                if (load.Axis == LoadAxis.Local)
+                    loadRecordForce.SetValue((short)IRobotUniformRecordValues.I_URV_LOCAL_SYSTEM, 1);
+
+                if (load.Projected)
+                    loadRecordForce.SetValue((short)IRobotUniformRecordValues.I_URV_PROJECTED, 1);
             }
 
             if (load.Moment.Length() != 0)
@@ -155,7 +161,13 @@ namespace BH.Engine.Robot
                 loadRecordMoment.SetValue((short)IRobotBarMomentDistributedRecordValues.I_BMDRV_MX, load.Moment.X);
                 loadRecordMoment.SetValue((short)IRobotBarMomentDistributedRecordValues.I_BMDRV_MY, load.Moment.Y);
                 loadRecordMoment.SetValue((short)IRobotBarMomentDistributedRecordValues.I_BMDRV_MZ, load.Moment.Z);
-            }
+
+                if (load.Axis == LoadAxis.Local)
+                    loadRecordMoment.SetValue((short)IRobotUniformRecordValues.I_URV_LOCAL_SYSTEM, 1);
+
+                if (load.Projected)
+                    loadRecordMoment.SetValue((short)IRobotUniformRecordValues.I_URV_PROJECTED, 1);
+            }                      
 
         }
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->


 ### Issues addressed by this PR
 Closes #270 

I pasted the code that allows for custom axis to be set into the if statements that creates the load if it exists. 

 ### Test files
https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?csf=1&e=CJWjNz&cid=0b727f4a%2Daf39%2D4d1d%2D8942%2D0c26c33d7c20&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4&viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FRobot%5FToolkit%2FRobot%5FToolkit%2DPR%20push%20load%20with%20local%20axis

how to test:
open test grasshopper file, toggle everything to true and look in the Robot loadtable to see if the axis is local:
![image](https://user-images.githubusercontent.com/54712802/67492289-17f0c000-f66e-11e9-9f10-7b10a25701b4.png)

 ### Additional comments