### PR TITLE
Remove setting label when pushing loadcases

### DIFF
--- a/Robot_Adapter/Create/LoadCombination.cs
+++ b/Robot_Adapter/Create/LoadCombination.cs
@@ -34,6 +34,7 @@ namespace BH.Adapter.Robot
 
         private bool CreateCollection(IEnumerable<LoadCombination> lComabinations)
         {
+            m_RobotApplication.Project.Structure.Cases.BeginMultiOperation();
             foreach (LoadCombination lComb in lComabinations)
             {
                 if (m_RobotApplication.Project.Structure.Cases.Exist(lComb.Number)!=-1)
@@ -41,7 +42,9 @@ namespace BH.Adapter.Robot
                     RobotCaseCombination rCaseCombination = m_RobotApplication.Project.Structure.Cases.CreateCombination(lComb.Number, lComb.Name, IRobotCombinationType.I_CBT_ULS, IRobotCaseNature.I_CN_PERMANENT, IRobotCaseAnalizeType.I_CAT_COMB);
                     for (int i = 0; i < lComb.LoadCases.Count; i++)
                     {
-                        rCaseCombination.CaseFactors.New(lComb.LoadCases[i].Item2.Number, lComb.LoadCases[i].Item1);
+                        System.Tuple<double, ICase> loadcase = lComb.LoadCases[i];
+                        if(loadcase.Item1 != 0)
+                            rCaseCombination.CaseFactors.New(lComb.LoadCases[i].Item2.Number, lComb.LoadCases[i].Item1);
                     }
                     updateview();
                 }
@@ -51,6 +54,7 @@ namespace BH.Adapter.Robot
                         "to clear combinations before re-pushing");
                 }
             }
+            m_RobotApplication.Project.Structure.Cases.EndMultiOperation();
             return true;
         }
 

--- a/Robot_Adapter/Create/LoadCombination.cs
+++ b/Robot_Adapter/Create/LoadCombination.cs
@@ -43,8 +43,7 @@ namespace BH.Adapter.Robot
                     for (int i = 0; i < lComb.LoadCases.Count; i++)
                     {
                         System.Tuple<double, ICase> loadcase = lComb.LoadCases[i];
-                        if(loadcase.Item1 != 0)
-                            rCaseCombination.CaseFactors.New(lComb.LoadCases[i].Item2.Number, lComb.LoadCases[i].Item1);
+                        rCaseCombination.CaseFactors.New(lComb.LoadCases[i].Item2.Number, lComb.LoadCases[i].Item1);
                     }
                     updateview();
                 }

--- a/Robot_Adapter/Create/Loadcase.cs
+++ b/Robot_Adapter/Create/Loadcase.cs
@@ -45,7 +45,8 @@ namespace BH.Adapter.Robot
                 IRobotCaseNature rNature = BH.Engine.Robot.Convert.RobotLoadNature(caseList[i], out subNature);
                 m_RobotApplication.Project.Structure.Cases.CreateSimple(caseList[i].Number, caseList[i].Name, rNature, IRobotCaseAnalizeType.I_CAT_STATIC_LINEAR);
                 IRobotSimpleCase sCase = caseServer.Get(caseList[i].Number) as IRobotSimpleCase;
-                sCase.label = (caseList[i].CustomData.ContainsKey("Label"))? caseList[i].CustomData["Label"].ToString() : "";
+                object labelName;
+                sCase.label = (caseList[i].CustomData.TryGetValue("Label", out labelName) && labelName is string)? labelName as string: "";
                 if (subNature >= 0)               
                     sCase.SetNatureExt(subNature);
             }

--- a/Robot_Adapter/Create/Loadcase.cs
+++ b/Robot_Adapter/Create/Loadcase.cs
@@ -43,9 +43,10 @@ namespace BH.Adapter.Robot
             {                
                 int subNature;
                 IRobotCaseNature rNature = BH.Engine.Robot.Convert.RobotLoadNature(caseList[i], out subNature);
-                m_RobotApplication.Project.Structure.Cases.CreateSimple(caseList[i].Number, caseList[i].Name, rNature, IRobotCaseAnalizeType.I_CAT_STATIC_LINEAR);                
+                m_RobotApplication.Project.Structure.Cases.CreateSimple(caseList[i].Number, caseList[i].Name, rNature, IRobotCaseAnalizeType.I_CAT_STATIC_LINEAR);
                 IRobotSimpleCase sCase = caseServer.Get(caseList[i].Number) as IRobotSimpleCase;
-                if (subNature >= 0)
+                sCase.label = (caseList[i].CustomData.ContainsKey("Label"))? caseList[i].CustomData["Label"].ToString() : "";
+                if (subNature >= 0)               
                     sCase.SetNatureExt(subNature);
             }
             m_RobotApplication.Project.Structure.Cases.EndMultiOperation();


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #269 


 ### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/Robot_Toolkit/Issues/Issue280-Ignore%20zero%20factor%20loadcases%20in%20combinations?csf=1&e=GL4Kfh

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
 - Loadcases no longer push the 'name' into the 'label'. To set the label, add a 'Label' to the loadcase CustomData before pushing
 - MultiIOperation applied to load combinations to speed up creation.

 ### Additional comments
<!-- As required -->
