### PR TITLE
Ensure Robot is not crashing when pushing unsupported sections

### DIFF
--- a/Robot_Engine/Convert/FromRobot/SectionProperty_Concrete.cs
+++ b/Robot_Engine/Convert/FromRobot/SectionProperty_Concrete.cs
@@ -131,25 +131,6 @@ namespace BH.Engine.Robot
 
         /***************************************************/
 
-        private static void ConcreteSection(this FreeFormProfile section, IMaterialFragment material, IRobotBarSectionData sectionData)
-        {
-            sectionData.MaterialName = material.Name;
-            ConcreteSection steelSection = BH.Engine.Structure.Create.ConcreteSectionFromProfile(section, material as Concrete);
-
-            sectionData.SetValue(IRobotBarSectionDataValue.I_BSDV_AX, steelSection.Area);
-            sectionData.SetValue(IRobotBarSectionDataValue.I_BSDV_IX, steelSection.J);
-            sectionData.SetValue(IRobotBarSectionDataValue.I_BSDV_IY, steelSection.Iy);
-            sectionData.SetValue(IRobotBarSectionDataValue.I_BSDV_IZ, steelSection.Iz);
-            sectionData.SetValue(IRobotBarSectionDataValue.I_BSDV_VY, steelSection.Vy);
-            sectionData.SetValue(IRobotBarSectionDataValue.I_BSDV_VZ, steelSection.Vz);
-            sectionData.SetValue(IRobotBarSectionDataValue.I_BSDV_VPY, steelSection.Vpy);
-            sectionData.SetValue(IRobotBarSectionDataValue.I_BSDV_VPZ, steelSection.Vpz);
-
-            sectionData.CalcNonstdGeometry();
-        }
-
-        /***************************************************/
-
         private static void ConcreteSection(this IProfile section, IMaterialFragment material, IRobotBarSectionData sectionData)
         {
             Reflection.Compute.RecordWarning("Profile of type " + section.GetType().Name + "is not yet fully supported for Concrete sections. Section with name " + sectionData.Name + " set as explicit section");

--- a/Robot_Engine/Convert/FromRobot/SectionProperty_Concrete.cs
+++ b/Robot_Engine/Convert/FromRobot/SectionProperty_Concrete.cs
@@ -150,6 +150,27 @@ namespace BH.Engine.Robot
 
         /***************************************************/
 
+        private static void ConcreteSection(this IProfile section, IMaterialFragment material, IRobotBarSectionData sectionData)
+        {
+            Reflection.Compute.RecordWarning("Profile of type " + section.GetType().Name + "is not yet fully supported for Concrete sections. Section with name " + sectionData.Name + " set as explicit section");
+
+            sectionData.MaterialName = material.Name;
+            ConcreteSection steelSection = BH.Engine.Structure.Create.ConcreteSectionFromProfile(section, material as Concrete);
+
+            sectionData.SetValue(IRobotBarSectionDataValue.I_BSDV_AX, steelSection.Area);
+            sectionData.SetValue(IRobotBarSectionDataValue.I_BSDV_IX, steelSection.J);
+            sectionData.SetValue(IRobotBarSectionDataValue.I_BSDV_IY, steelSection.Iy);
+            sectionData.SetValue(IRobotBarSectionDataValue.I_BSDV_IZ, steelSection.Iz);
+            sectionData.SetValue(IRobotBarSectionDataValue.I_BSDV_VY, steelSection.Vy);
+            sectionData.SetValue(IRobotBarSectionDataValue.I_BSDV_VZ, steelSection.Vz);
+            sectionData.SetValue(IRobotBarSectionDataValue.I_BSDV_VPY, steelSection.Vpy);
+            sectionData.SetValue(IRobotBarSectionDataValue.I_BSDV_VPZ, steelSection.Vpz);
+
+            sectionData.CalcNonstdGeometry();
+        }
+
+        /***************************************************/
+
         public static ISectionProperty BHoMConcreteSection(IRobotBarSectionData secData)
         {
             double b = 0;

--- a/Robot_Engine/Convert/FromRobot/SectionProperty_Steel.cs
+++ b/Robot_Engine/Convert/FromRobot/SectionProperty_Steel.cs
@@ -377,25 +377,6 @@ namespace BH.Engine.Robot
 
         /***************************************************/
 
-        private static void SteelSection(this FreeFormProfile section, IMaterialFragment material, IRobotBarSectionData sectionData)
-        {
-            sectionData.MaterialName = material.Name;
-            SteelSection steelSection = BH.Engine.Structure.Create.SteelSectionFromProfile(section, material as Steel);
-
-            sectionData.SetValue(IRobotBarSectionDataValue.I_BSDV_AX, steelSection.Area);
-            sectionData.SetValue(IRobotBarSectionDataValue.I_BSDV_IX, steelSection.J);
-            sectionData.SetValue(IRobotBarSectionDataValue.I_BSDV_IY, steelSection.Iy);
-            sectionData.SetValue(IRobotBarSectionDataValue.I_BSDV_IZ, steelSection.Iz);
-            sectionData.SetValue(IRobotBarSectionDataValue.I_BSDV_VY, steelSection.Vy);
-            sectionData.SetValue(IRobotBarSectionDataValue.I_BSDV_VZ, steelSection.Vz);
-            sectionData.SetValue(IRobotBarSectionDataValue.I_BSDV_VPY, steelSection.Vpy);
-            sectionData.SetValue(IRobotBarSectionDataValue.I_BSDV_VPZ, steelSection.Vpz);
-
-            sectionData.CalcNonstdGeometry();
-        }
-
-        /***************************************************/
-
         private static void SteelSection(this GeneralisedFabricatedBoxProfile section, IMaterialFragment material, IRobotBarSectionData sectionData)
         {
             sectionData.Type = IRobotBarSectionType.I_BST_NS_BOX_3;
@@ -413,26 +394,6 @@ namespace BH.Engine.Robot
             nonStdData.SetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_BOX_3_TW, section.WebThickness);
             nonStdData.SetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_BOX_3_TF, section.TopFlangeThickness);
             nonStdData.SetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_BOX_3_TF2, section.BotFlangeThickness);
-
-            sectionData.CalcNonstdGeometry();
-
-        }
-
-        /***************************************************/
-
-        private static void SteelSection(this KiteProfile section, IMaterialFragment material, IRobotBarSectionData sectionData)
-        {
-            sectionData.MaterialName = material.Name;
-            SteelSection steelSection = BH.Engine.Structure.Create.SteelSectionFromProfile(section, material as Steel);
-
-            sectionData.SetValue(IRobotBarSectionDataValue.I_BSDV_AX, steelSection.Area);
-            sectionData.SetValue(IRobotBarSectionDataValue.I_BSDV_IX, steelSection.J);
-            sectionData.SetValue(IRobotBarSectionDataValue.I_BSDV_IY, steelSection.Iy);
-            sectionData.SetValue(IRobotBarSectionDataValue.I_BSDV_IZ, steelSection.Iz);
-            sectionData.SetValue(IRobotBarSectionDataValue.I_BSDV_VY, steelSection.Vy);
-            sectionData.SetValue(IRobotBarSectionDataValue.I_BSDV_VZ, steelSection.Vz);
-            sectionData.SetValue(IRobotBarSectionDataValue.I_BSDV_VPY, steelSection.Vpy);
-            sectionData.SetValue(IRobotBarSectionDataValue.I_BSDV_VPZ, steelSection.Vpz);
 
             sectionData.CalcNonstdGeometry();
 

--- a/Robot_Engine/Convert/FromRobot/SectionProperty_Steel.cs
+++ b/Robot_Engine/Convert/FromRobot/SectionProperty_Steel.cs
@@ -146,7 +146,7 @@ namespace BH.Engine.Robot
                         H = nonStdData.GetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_BOX_2_H);
                         TW = nonStdData.GetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_BOX_2_TW);
                         TF = nonStdData.GetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_BOX_2_TF);
-                        sectionProfile = BH.Engine.Geometry.Create.GeneralisedFabricatedBoxProfile(H + (2*TF), B1 + (2 * TW), TW, TF, TF, (B - B1 - (2 * TW)) / 2, (B - B1 - (2 * TW)) / 2);
+                        sectionProfile = BH.Engine.Geometry.Create.GeneralisedFabricatedBoxProfile(H + (2 * TF), B1 + (2 * TW), TW, TF, TF, (B - B1 - (2 * TW)) / 2, (B - B1 - (2 * TW)) / 2);
                         return BH.Engine.Structure.Create.SteelSectionFromProfile(sectionProfile);
 
                     case IRobotBarSectionShapeType.I_BSST_USER_BOX_3:
@@ -157,7 +157,7 @@ namespace BH.Engine.Robot
                         TW = nonStdData.GetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_BOX_3_TW);
                         TF = nonStdData.GetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_BOX_3_TF);
                         TF2 = nonStdData.GetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_BOX_3_TF2);
-                        sectionProfile = BH.Engine.Geometry.Create.GeneralisedFabricatedBoxProfile(H + TF + TF2, B1 + (2*TW), TW, TF, TF2, (B2 - B1 - (2*TW))/2, (B - B1 - (2 * TW))/2);
+                        sectionProfile = BH.Engine.Geometry.Create.GeneralisedFabricatedBoxProfile(H + TF + TF2, B1 + (2 * TW), TW, TF, TF2, (B2 - B1 - (2 * TW)) / 2, (B - B1 - (2 * TW)) / 2);
                         return BH.Engine.Structure.Create.SteelSectionFromProfile(sectionProfile);
 
                     case IRobotBarSectionShapeType.I_BSST_BOX:
@@ -436,6 +436,27 @@ namespace BH.Engine.Robot
 
             sectionData.CalcNonstdGeometry();
 
+        }
+
+        /***************************************************/
+
+        private static void SteelSection(this IProfile section, IMaterialFragment material, IRobotBarSectionData sectionData)
+        {
+            Reflection.Compute.RecordWarning("Profile of type " + section.GetType().Name + "is not yet fully supported for Steel sections. Section with name " + sectionData.Name + " set as explicit section");
+
+            sectionData.MaterialName = material.Name;
+            SteelSection steelSection = BH.Engine.Structure.Create.SteelSectionFromProfile(section, material as Steel);
+
+            sectionData.SetValue(IRobotBarSectionDataValue.I_BSDV_AX, steelSection.Area);
+            sectionData.SetValue(IRobotBarSectionDataValue.I_BSDV_IX, steelSection.J);
+            sectionData.SetValue(IRobotBarSectionDataValue.I_BSDV_IY, steelSection.Iy);
+            sectionData.SetValue(IRobotBarSectionDataValue.I_BSDV_IZ, steelSection.Iz);
+            sectionData.SetValue(IRobotBarSectionDataValue.I_BSDV_VY, steelSection.Vy);
+            sectionData.SetValue(IRobotBarSectionDataValue.I_BSDV_VZ, steelSection.Vz);
+            sectionData.SetValue(IRobotBarSectionDataValue.I_BSDV_VPY, steelSection.Vpy);
+            sectionData.SetValue(IRobotBarSectionDataValue.I_BSDV_VPZ, steelSection.Vpz);
+
+            sectionData.CalcNonstdGeometry();
         }
 
         /***************************************************/

--- a/Robot_Engine/Convert/Private Helpers/SectionProperty.cs
+++ b/Robot_Engine/Convert/Private Helpers/SectionProperty.cs
@@ -41,24 +41,29 @@ namespace BH.Engine.Robot
 
         /***************************************************/
 
-        public static void SectionProperty(this ExplicitSection section, Material material, IRobotBarSectionData secData)
+        public static void SectionProperty(this ExplicitSection section, IMaterialFragment material, IRobotBarSectionData secData)
         {
-            
+            secData.MaterialName = material.Name;
+
+            secData.SetValue(IRobotBarSectionDataValue.I_BSDV_AX, section.Area);
+            secData.SetValue(IRobotBarSectionDataValue.I_BSDV_IX, section.J);
+            secData.SetValue(IRobotBarSectionDataValue.I_BSDV_IY, section.Iy);
+            secData.SetValue(IRobotBarSectionDataValue.I_BSDV_IZ, section.Iz);
+            secData.SetValue(IRobotBarSectionDataValue.I_BSDV_VY, section.Vy);
+            secData.SetValue(IRobotBarSectionDataValue.I_BSDV_VZ, section.Vz);
+            secData.SetValue(IRobotBarSectionDataValue.I_BSDV_VPY, section.Vpy);
+            secData.SetValue(IRobotBarSectionDataValue.I_BSDV_VPZ, section.Vpz);
+
+            secData.CalcNonstdGeometry();
         }
 
         /***************************************************/
 
-        public static void SectionProperty(this CableSection section, Material material, IRobotBarSectionData secData)
+        public static void SectionProperty(this ISectionProperty section, IMaterialFragment material, IRobotBarSectionData secData)
         {
-            
+            secData.MaterialName = material.Name;
+            Engine.Reflection.Compute.RecordWarning("Section of type " + section.GetType().Name + " is not yet supported in the Robot adapter. Section with name " + secData.Name + " will not have any properties set");
         }
-
-        /***************************************************/
-
-        //private static void SectionShapeType(this IList<ICurve> edges, IRobotBarSectionData secData)
-        //{
-        //    throw new NotImplementedException();
-        //}
 
         /***************************************************/
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->


 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #265 

 <!-- Add short description of what has been fixed -->

Adding fallback methods for profiles for Steel and concrete sections, support for explicit sections and fallback for general section properties.

 ### Test files
<!-- Link to test files to validate the proposed changes -->

Test of cable and explicit section (Fallback for cable and implemented explicit)

https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/Robot_Toolkit/Issues/Issue265-HandleNonImplementedSections?csf=1&e=6jXt3J

General batch test of bars, testing fallback of profiles:

https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/Robot_Toolkit/_Macro/Push?csf=1&e=yXgOSt

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->

- Fallback methods added for section management to ensure Robot is nto crashing when pushing sections not yet supported
- Steel and Concrete sections get pushed as explicit sections for profiles not supported. Warning Raised to state that this has happened
- Support for Explicit section added
- All other sections have fallback method added. Added as explicit with no section data. Warning raised to state that this has happened.

 ### Additional comments
<!-- As required -->
