### PR TITLE
Returning not yet supported panels as NaN thickness proeprties

### DIFF
--- a/Robot_Engine/Convert/FromRobot/Property2D.cs
+++ b/Robot_Engine/Convert/FromRobot/Property2D.cs
@@ -88,6 +88,8 @@ namespace BH.Engine.Robot
                             case IRobotThicknessOrthoType.I_TOT_BIDIR_BOX_FLOOR:
                             case IRobotThicknessOrthoType.I_TOT_HOLLOW_CORE_SLAB:
                             case IRobotThicknessOrthoType.I_TOT_USER:
+                                BHoMProperty = new ConstantThickness { Name = rLabel.Name, Thickness = double.NaN, Material = mat };
+                                Reflection.Compute.RecordWarning("Could not pull property of type " + orthoData.Type + " with name " + rLabel.Name + ". A constant thickness property with NaN thickness as been created in its place");
                                 break;
                             default:
                                 BHoMProperty = new ConstantThickness { Name = rLabel.Name, Thickness = orthoData.H, Material = mat };


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #284 

 <!-- Add short description of what has been fixed -->

Returning non-supported properties as Constant thickness with NaN thickness. Doing this to avoid reading back panels crashing and to give back as much information as possible to the user

 ### Test files
<!-- Link to test files to validate the proposed changes -->

https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/Robot_Toolkit/Robot_Toolkit-Issue%20284%20Pull%20panels?csf=1&e=pmrQHO

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->

- Not yet supported `SurfaceProperties` are returned as ConstantThickness proeprties with NaN thickness. Warning raised to state that this has happened.

 ### Additional comments
<!-- As required -->
