### PR TITLE
Add member lengths to FramingElementDesignProperties

### DIFF
--- a/Robot_Adapter/Create/FramingElementDesignProperties.cs
+++ b/Robot_Adapter/Create/FramingElementDesignProperties.cs
@@ -41,6 +41,17 @@ namespace BH.Adapter.Robot
 
             IRDimMembDef memberDef = label.Data;
 
+            if (framEleDesProps.MemberLengthYIsRelative)
+                memberDef.SetLengthYZUV(IRDimMembDefLengthDataType.I_DMDLDT_LENGTH_Y, -framEleDesProps.MemberLengthY);
+            else
+                memberDef.SetLengthYZUV(IRDimMembDefLengthDataType.I_DMDLDT_LENGTH_Y, framEleDesProps.MemberLengthY);
+
+            if (framEleDesProps.MemberLengthZIsRelative)
+                memberDef.SetLengthYZUV(IRDimMembDefLengthDataType.I_DMDLDT_LENGTH_Z, -framEleDesProps.MemberLengthZ);
+            else
+                memberDef.SetLengthYZUV(IRDimMembDefLengthDataType.I_DMDLDT_LENGTH_Z, framEleDesProps.MemberLengthZ);
+
+
             string steelMembersCodeType = m_RobotApplication.Project.Preferences.GetActiveCode(IRobotCodeType.I_CT_STEEL_STRUCTURES);
 
             if (steelMembersCodeType == BHE.Query.GetStringFromEnum(DesignCode_Steel.BS_EN_1993_1_2005_NA_2008_A1_2014))

--- a/Robot_Adapter/Read/Properties/FramingElementDesignProperties.cs
+++ b/Robot_Adapter/Read/Properties/FramingElementDesignProperties.cs
@@ -121,6 +121,29 @@ namespace BH.Adapter.Robot
                     bhomDesignProps.EulerBucklingLengthCoefficientY = memberDesignParams_BS5950_2000.BuckLengthCoeffY;
                     bhomDesignProps.EulerBucklingLengthCoefficientZ = memberDesignParams_BS5950_2000.BuckLengthCoeffZ;
                 }
+
+                if (memberDef.LengthYZUV(IRDimMembDefLengthDataType.I_DMDLDT_LENGTH_Y) < 0)
+                {
+                    bhomDesignProps.MemberLengthY = -memberDef.LengthYZUV(IRDimMembDefLengthDataType.I_DMDLDT_LENGTH_Y);
+                    bhomDesignProps.MemberLengthYIsRelative = true;
+                }
+                else
+                {
+                    bhomDesignProps.MemberLengthY = memberDef.LengthYZUV(IRDimMembDefLengthDataType.I_DMDLDT_LENGTH_Y);
+                    bhomDesignProps.MemberLengthYIsRelative = false;
+                }
+
+                if (memberDef.LengthYZUV(IRDimMembDefLengthDataType.I_DMDLDT_LENGTH_Z) < 0)
+                {
+                    bhomDesignProps.MemberLengthZ = -memberDef.LengthYZUV(IRDimMembDefLengthDataType.I_DMDLDT_LENGTH_Z);
+                    bhomDesignProps.MemberLengthZIsRelative = true;
+                }
+                else
+                {
+                    bhomDesignProps.MemberLengthZ = memberDef.LengthYZUV(IRDimMembDefLengthDataType.I_DMDLDT_LENGTH_Z);
+                    bhomDesignProps.MemberLengthZIsRelative = false;
+                }
+
                 bhomDesignPropsList.Add(bhomDesignProps);
             }
             return bhomDesignPropsList;

--- a/Robot_oM/Structural/Properties/FramingElementDesignProperties.cs
+++ b/Robot_oM/Structural/Properties/FramingElementDesignProperties.cs
@@ -32,6 +32,10 @@ namespace BH.oM.Adapters.Robot
 
         public double EulerBucklingLengthCoefficientY { get; set; } = 1;
         public double EulerBucklingLengthCoefficientZ { get; set; } = 1;
+        public double MemberLengthY { get; set; } = 1;
+        public double MemberLengthZ { get; set; } = 1;
+        public bool MemberLengthYIsRelative { get; set; } = true;
+        public bool MemberLengthZIsRelative { get; set; } = true;
 
         /***************************************************/
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->


 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #295 

 <!-- Add short description of what has been fixed -->
Reads and sets member lengths in X and Y and toggles for whether lengths are real or relative. Happy for input on parameter naming and improvements to the code.

 ### Test files
<!-- Link to test files to validate the proposed changes -->
[Test files](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FRobot%5FToolkit%2FIssues%2FRobot%5FToolkit%2DIssue295%2DAddMemberLengths&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4)

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->
