### PR TITLE
Ensure panel materials are read when pulling panels

### DIFF
--- a/Robot_Adapter/CRUD/Read/Elements/Panel.cs
+++ b/Robot_Adapter/CRUD/Read/Elements/Panel.cs
@@ -149,7 +149,7 @@ namespace BH.Adapter.Robot
                         {
                             if (!bhomProperties.ContainsKey(propName))
                             {
-                                ISurfaceProperty property2D = ReadProperty2DFromPanel(robotCladdingPanel, bhomMaterials);
+                                ISurfaceProperty property2D = ReadProperty2DFromPanel(robotCladdingPanel, bhomMaterials, true);
                                 if (property2D.Material == null) property2D.Material = ReadMaterialFromPanel(robotCladdingPanel);
                                 bhomProperties.Add(propName, property2D);
                             }

--- a/Robot_Adapter/CRUD/Read/Elements/Panel.cs
+++ b/Robot_Adapter/CRUD/Read/Elements/Panel.cs
@@ -43,6 +43,7 @@ namespace BH.Adapter.Robot
             List<Panel> BHoMPanels = new List<Panel>();
             IRobotStructure robotStructureServer = m_RobotApplication.Project.Structure;
             IRobotObjObjectServer robotPanelServer = m_RobotApplication.Project.Structure.Objects;
+            IRobotLabelServer robotLabelServer = m_RobotApplication.Project.Structure.Labels;
             List<Material> bhomMaterials = new List<Material>();
             List<Opening> allOpenings = ReadOpenings();
             Panel BHoMPanel = null;
@@ -108,13 +109,20 @@ namespace BH.Adapter.Robot
                     BH.oM.Geometry.CoordinateSystem.Cartesian tempCoordSys = BH.Engine.Geometry.Create.CartesianCoordinateSystem(coordPoint, coordXAxis, coordZAxis);
                     BH.oM.Geometry.CoordinateSystem.Cartesian coordinateSystem = BH.Engine.Geometry.Create.CartesianCoordinateSystem(coordPoint, coordXAxis, tempCoordSys.Z);                    
 
-                    BHoMPanel.CustomData["CoordinateSystem"] = coordinateSystem;
-
+                    BHoMPanel.CustomData["CoordinateSystem"] = coordinateSystem;                
                     if (rpanel.HasLabel(IRobotLabelType.I_LT_PANEL_THICKNESS) != 0)
                     {
                         string propName = rpanel.GetLabelName(IRobotLabelType.I_LT_PANEL_THICKNESS);
                         if (BHoMProperties.ContainsKey(propName))
+                        {
+                            if(BHoMProperties[propName].Material == null)
+                            {
+                                IRobotLabel thicknessLabel = rpanel.GetLabel(IRobotLabelType.I_LT_PANEL_THICKNESS);
+                                IRobotThicknessData thicknessData = thicknessLabel.Data;
+                                BHoMProperties[propName].Material = MaterialFromLabel(robotLabelServer.Get(IRobotLabelType.I_LT_MATERIAL, thicknessData.MaterialName));
+                            }
                             BHoMPanel.Property = BHoMProperties[propName];
+                        }
                         else
                             BH.Engine.Reflection.Compute.RecordEvent("Failed to convert/create ConstantThickness property for panel " + rpanel.Number.ToString(), oM.Reflection.Debugging.EventType.Warning);
                     }

--- a/Robot_Adapter/CRUD/Read/Elements/Panel.cs
+++ b/Robot_Adapter/CRUD/Read/Elements/Panel.cs
@@ -40,12 +40,13 @@ namespace BH.Adapter.Robot
 
         private List<Panel> ReadPanels(IList ids = null)
         {
-            Dictionary<string, ISurfaceProperty> BHoMProperties = ReadProperty2D().ToDictionary(x => x.Name);
+            Dictionary<string, ISurfaceProperty> bhomProperties = new Dictionary<string, ISurfaceProperty>();
+            Dictionary<string, IMaterialFragment> bhomMaterials = new Dictionary<string, IMaterialFragment>();
             List<Panel> BHoMPanels = new List<Panel>();
             IRobotStructure robotStructureServer = m_RobotApplication.Project.Structure;
             IRobotObjObjectServer robotPanelServer = m_RobotApplication.Project.Structure.Objects;
             IRobotLabelServer robotLabelServer = m_RobotApplication.Project.Structure.Labels;
-            Dictionary<string, IMaterialFragment> bhomMaterials = BHoMProperties.Where(x => x.Value.Material != null).Select(x => x.Value.Material as IMaterialFragment).ToDictionary(x => x.Name);
+
             List<Opening> allOpenings = ReadOpenings();
             Panel BHoMPanel = null;
 
@@ -114,14 +115,13 @@ namespace BH.Adapter.Robot
                     if (robotPanel.HasLabel(IRobotLabelType.I_LT_PANEL_THICKNESS) != 0)
                     {
                         string propName = robotPanel.GetLabelName(IRobotLabelType.I_LT_PANEL_THICKNESS);
-                        if (!BHoMProperties.ContainsKey(propName))
-                            BHoMProperties.Add(propName, ReadProperty2DFromPanel(robotPanel, bhomMaterials));
-                        else
+                        if (!bhomProperties.ContainsKey(propName))
                         {
-                            ISurfaceProperty property2D = BHoMProperties[propName];
+                            ISurfaceProperty property2D = ReadProperty2DFromPanel(robotPanel, bhomMaterials);
                             if (property2D.Material == null) property2D.Material = ReadMaterialFromPanel(robotPanel);
-                            BHoMPanel.Property = BHoMProperties[propName];
+                            bhomProperties.Add(propName, property2D);
                         }
+                        BHoMPanel.Property = bhomProperties[propName];
                     }
                     BHoMPanels.Add(BHoMPanel);
                 }
@@ -147,14 +147,13 @@ namespace BH.Adapter.Robot
                         string propName = robotCladdingPanel.GetLabelName(IRobotLabelType.I_LT_CLADDING);
                         if (propName != "")
                         {
-                            if (!BHoMProperties.ContainsKey(propName))
-                                BHoMProperties.Add(propName, ReadProperty2DFromPanel(robotCladdingPanel, bhomMaterials));
-                            else
+                            if (!bhomProperties.ContainsKey(propName))
                             {
-                                ISurfaceProperty property2D = BHoMProperties[propName];
+                                ISurfaceProperty property2D = ReadProperty2DFromPanel(robotCladdingPanel, bhomMaterials);
                                 if (property2D.Material == null) property2D.Material = ReadMaterialFromPanel(robotCladdingPanel);
-                                BHoMPanel.Property = BHoMProperties[propName];
+                                bhomProperties.Add(propName, property2D);
                             }
+                            BHoMPanel.Property = bhomProperties[propName];
                         }
                     }
                     BHoMPanels.Add(BHoMPanel);

--- a/Robot_Adapter/CRUD/Read/Elements/Panel.cs
+++ b/Robot_Adapter/CRUD/Read/Elements/Panel.cs
@@ -150,7 +150,6 @@ namespace BH.Adapter.Robot
                             if (!bhomProperties.ContainsKey(propName))
                             {
                                 ISurfaceProperty property2D = ReadProperty2DFromPanel(robotCladdingPanel, bhomMaterials, true);
-                                if (property2D.Material == null) property2D.Material = ReadMaterialFromPanel(robotCladdingPanel);
                                 bhomProperties.Add(propName, property2D);
                             }
                             BHoMPanel.Property = bhomProperties[propName];

--- a/Robot_Adapter/CRUD/Read/Properties/Material.cs
+++ b/Robot_Adapter/CRUD/Read/Properties/Material.cs
@@ -110,16 +110,7 @@ namespace BH.Adapter.Robot
             IRobotLabelServer robotLabelServer = m_RobotApplication.Project.Structure.Labels;
             IRobotLabel thicknessLabel = robotPanel.GetLabel(IRobotLabelType.I_LT_PANEL_THICKNESS);
             IRobotThicknessData thicknessData = thicknessLabel.Data;
-            IMaterialFragment material = null;
-            try
-            {
-                material = MaterialFromLabel(robotLabelServer.Get(IRobotLabelType.I_LT_MATERIAL, thicknessData.MaterialName));
-            }
-            catch
-            {
-                BH.Engine.Reflection.Compute.RecordWarning("No material is assigned for panel " + robotPanel.Number.ToString());
-            }
-            return material;
+            return MaterialFromLabel(robotLabelServer.Get(IRobotLabelType.I_LT_MATERIAL, thicknessData.MaterialName));
         }
     }
 }

--- a/Robot_Adapter/CRUD/Read/Properties/Material.cs
+++ b/Robot_Adapter/CRUD/Read/Properties/Material.cs
@@ -39,38 +39,14 @@ namespace BH.Adapter.Robot
             IMaterialFragment bhomMat = null;
             List<IMaterialFragment> bhomMaterials = new List<IMaterialFragment>();
 
-            //IRobotMaterialData mData;
-            //int counter = 0;
-            //bool refresh = false;
-            //
-            //foreach (string matName in m_dbMaterialNames)
-            //{
-            //    IRobotLabel label = labelServer.Create(IRobotLabelType.I_LT_MATERIAL, "");
-            //    mData = label.Data;
-            //    mData.LoadFromDBase(matName);
-            //    MaterialType bhomMatType = BH.Engine.Robot.Convert.GetMaterialType(mData.Type);
-            //    bhomMat = BH.Engine.Common.Create.Material(matName, bhomMatType, mData.E, mData.NU, mData.LX, mData.RO / Engine.Robot.Query.RobotGravityConstant);
-            //    if (m_indexDict.ContainsKey(bhomMat.GetType()) && counter == 0)
-            //        m_indexDict[bhomMat.GetType()] = 0;
-            //    bhomMat.CustomData.Add(AdapterIdName, NextId(bhomMat.GetType(), refresh));
-
-            //    //if (refresh)
-            //    //    refresh = false;
-
-            //    if (bhomMat != null)
-            //        bhomMaterials.Add(bhomMat);
-            //    counter++;
-            //}
-
             for (int i = 1; i <= rMaterials.Count; i++)
             {
-                IRobotLabel rMatLable = rMaterials.Get(i);
+                IRobotLabel robotMaterialLabel = rMaterials.Get(i);
 
-                bhomMat = MaterialFromLabel(rMatLable);
+                bhomMat = MaterialFromLabel(robotMaterialLabel);
 
                 if (bhomMat != null)
                     bhomMaterials.Add(bhomMat);
-                //}
             }
 
             return bhomMaterials;
@@ -83,18 +59,15 @@ namespace BH.Adapter.Robot
             IRobotLabel materialLabel = m_RobotApplication.Project.Structure.Labels.Get(IRobotLabelType.I_LT_MATERIAL, labelName);
             if(materialLabel != null)
                 return MaterialFromLabel(materialLabel);
-
             return null;
         }
 
         /***************************************************/
 
-        private IMaterialFragment MaterialFromLabel(IRobotLabel materialLabel)
+        private IMaterialFragment MaterialFromLabel(IRobotLabel robotMaterialLabel)
         {
-            IRobotMaterialData mData = materialLabel.Data as IRobotMaterialData;
-
+            IRobotMaterialData mData = robotMaterialLabel.Data as IRobotMaterialData;
             IMaterialFragment bhomMat;
-
             switch (mData.Type)
             {
                 case IRobotMaterialType.I_MT_STEEL:
@@ -112,8 +85,7 @@ namespace BH.Adapter.Robot
                 default:
                     Engine.Reflection.Compute.RecordWarning("Material of Robot type " + mData.Type + " not yet suported. Empty material will be provided");
                     return null;
-            }
-           
+            }           
             bhomMat.CustomData.Add(AdapterIdName, NextFreeId(bhomMat.GetType(), false));
             return bhomMat;
         }
@@ -133,6 +105,22 @@ namespace BH.Adapter.Robot
 
         /***************************************************/
 
+        private IMaterialFragment ReadMaterialFromPanel(IRobotObjObject robotPanel)
+        {
+            IRobotLabelServer robotLabelServer = m_RobotApplication.Project.Structure.Labels;
+            IRobotLabel thicknessLabel = robotPanel.GetLabel(IRobotLabelType.I_LT_PANEL_THICKNESS);
+            IRobotThicknessData thicknessData = thicknessLabel.Data;
+            IMaterialFragment material = null;
+            try
+            {
+                material = MaterialFromLabel(robotLabelServer.Get(IRobotLabelType.I_LT_MATERIAL, thicknessData.MaterialName));
+            }
+            catch
+            {
+                BH.Engine.Reflection.Compute.RecordWarning("No material is assigned for panel " + robotPanel.Number.ToString());
+            }
+            return material;
+        }
     }
 }
 

--- a/Robot_Adapter/CRUD/Read/Properties/Property2D.cs
+++ b/Robot_Adapter/CRUD/Read/Properties/Property2D.cs
@@ -70,7 +70,7 @@ namespace BH.Adapter.Robot
             if (bHoMMaterials == null) bHoMMaterials = new Dictionary<string, IMaterialFragment>();
             IRobotLabel thicknessLabel = robotPanel.GetLabel(IRobotLabelType.I_LT_PANEL_THICKNESS);
             IRobotThicknessData thicknessData = thicknessLabel.Data;
-            if (!bHoMMaterials.ContainsKey(thicknessData.MaterialName))
+            if (thicknessData.MaterialName != "" && !bHoMMaterials.ContainsKey(thicknessData.MaterialName))
                 bHoMMaterials.Add(thicknessData.MaterialName, MaterialFromLabel(robotLabelServer.Get(IRobotLabelType.I_LT_MATERIAL, thicknessData.MaterialName)));
             ISurfaceProperty thicknessProperty = BH.Engine.Robot.Convert.ToBHoMObject(thicknessLabel, bHoMMaterials);
             if (thicknessProperty == null)

--- a/Robot_Adapter/CRUD/Read/Properties/Property2D.cs
+++ b/Robot_Adapter/CRUD/Read/Properties/Property2D.cs
@@ -64,15 +64,25 @@ namespace BH.Adapter.Robot
 
         /***************************************************/
         
-        private ISurfaceProperty ReadProperty2DFromPanel(IRobotObjObject robotPanel, Dictionary<string, IMaterialFragment> bHoMMaterials = null)
+        private ISurfaceProperty ReadProperty2DFromPanel(IRobotObjObject robotPanel, Dictionary<string, IMaterialFragment> bHoMMaterials = null, bool isCladding = false)
         {
             IRobotLabelServer robotLabelServer = m_RobotApplication.Project.Structure.Labels;
             if (bHoMMaterials == null) bHoMMaterials = new Dictionary<string, IMaterialFragment>();
-            IRobotLabel thicknessLabel = robotPanel.GetLabel(IRobotLabelType.I_LT_PANEL_THICKNESS);
-            IRobotThicknessData thicknessData = thicknessLabel.Data;
-            if (thicknessData.MaterialName != "" && !bHoMMaterials.ContainsKey(thicknessData.MaterialName))
-                bHoMMaterials.Add(thicknessData.MaterialName, MaterialFromLabel(robotLabelServer.Get(IRobotLabelType.I_LT_MATERIAL, thicknessData.MaterialName)));
-            ISurfaceProperty thicknessProperty = BH.Engine.Robot.Convert.ToBHoMObject(thicknessLabel, bHoMMaterials);
+            IRobotLabel thicknessLabel = null;
+            ISurfaceProperty thicknessProperty = null;
+            if (!isCladding)
+            {
+                thicknessLabel = robotPanel.GetLabel(IRobotLabelType.I_LT_PANEL_THICKNESS);
+                IRobotThicknessData thicknessData = thicknessLabel.Data;
+                if (thicknessData.MaterialName != "" && !bHoMMaterials.ContainsKey(thicknessData.MaterialName))
+                    bHoMMaterials.Add(thicknessData.MaterialName, MaterialFromLabel(robotLabelServer.Get(IRobotLabelType.I_LT_MATERIAL, thicknessData.MaterialName)));
+                thicknessProperty = BH.Engine.Robot.Convert.ToBHoMObject(thicknessLabel, bHoMMaterials);
+            }
+            else
+            {
+                thicknessLabel = robotPanel.GetLabel(IRobotLabelType.I_LT_CLADDING);
+                thicknessProperty = BH.Engine.Robot.Convert.ToBHoMObject(thicknessLabel, bHoMMaterials);
+            }
             if (thicknessProperty == null)
             {
                 BH.Engine.Reflection.Compute.RecordEvent("Failed to convert/create ConstantThickness property for panel " + robotPanel.Number.ToString(), oM.Reflection.Debugging.EventType.Warning);

--- a/Robot_Adapter/CRUD/Read/Properties/Property2D.cs
+++ b/Robot_Adapter/CRUD/Read/Properties/Property2D.cs
@@ -63,6 +63,23 @@ namespace BH.Adapter.Robot
         }
 
         /***************************************************/
-
+        
+        private ISurfaceProperty ReadProperty2DFromPanel(IRobotObjObject robotPanel, Dictionary<string, IMaterialFragment> bHoMMaterials = null)
+        {
+            IRobotLabelServer robotLabelServer = m_RobotApplication.Project.Structure.Labels;
+            if (bHoMMaterials == null) bHoMMaterials = new Dictionary<string, IMaterialFragment>();
+            IRobotLabel thicknessLabel = robotPanel.GetLabel(IRobotLabelType.I_LT_PANEL_THICKNESS);
+            IRobotThicknessData thicknessData = thicknessLabel.Data;
+            if (!bHoMMaterials.ContainsKey(thicknessData.MaterialName))
+                bHoMMaterials.Add(thicknessData.MaterialName, MaterialFromLabel(robotLabelServer.Get(IRobotLabelType.I_LT_MATERIAL, thicknessData.MaterialName)));
+            ISurfaceProperty thicknessProperty = BH.Engine.Robot.Convert.ToBHoMObject(thicknessLabel, bHoMMaterials);
+            if (thicknessProperty == null)
+            {
+                BH.Engine.Reflection.Compute.RecordEvent("Failed to convert/create ConstantThickness property for panel " + robotPanel.Number.ToString(), oM.Reflection.Debugging.EventType.Warning);
+                return null;
+            }
+            else
+                return thicknessProperty;
+        }
     }
 }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #303 

 <!-- Add short description of what has been fixed -->


 ### Test files
<!-- Link to test files to validate the proposed changes -->
See #303 

Pull panels without the fix, and several of the panels at the start of the returned list will have null material on the thickness property. With the fix, concrete properties should be pulled. Note that the model also contains cladding/load panels, which are not expected to return any thickness property/material.

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->
