### PR TITLE
Failsafe for section pull and bug fixes for sections

### DIFF
--- a/Robot_Adapter/CRUD/Read/Properties/SectionProperties.cs
+++ b/Robot_Adapter/CRUD/Read/Properties/SectionProperties.cs
@@ -83,6 +83,10 @@ namespace BH.Adapter.Robot
                     bhomSec.CustomData[AdapterIdName] = rSection.Name;
                     bhomSectionProps.Add(bhomSec);
                 }
+                else
+                {
+                    Engine.Reflection.Compute.RecordWarning("Unable to convert section named " + rSection.Name);
+                }
             }
             return bhomSectionProps;
         }

--- a/Robot_Adapter/Convert/FromRobot/Properties/SectionProperty_Concrete.cs
+++ b/Robot_Adapter/Convert/FromRobot/Properties/SectionProperty_Concrete.cs
@@ -61,7 +61,7 @@ namespace BH.Adapter.Robot
                     h = concMember.GetValue(IRobotBarSectionConcreteDataValue.I_BSCDV_BEAM_H);
                     b = concMember.GetValue(IRobotBarSectionConcreteDataValue.I_BSCDV_BEAM_B);
                     sectionProfile = BH.Engine.Geometry.Create.RectangleProfile(b, h, 0);
-                    return BH.Engine.Structure.Create.ConcreteSectionFromProfile(sectionProfile);
+                    break;
 
                 case IRobotBarSectionShapeType.I_BSST_CONCR_BEAM_I:
                     b1 = concMember.GetValue(IRobotBarSectionConcreteDataValue.I_BSCDV_BEAM_I_B1);
@@ -71,7 +71,7 @@ namespace BH.Adapter.Robot
                     h = concMember.GetValue(IRobotBarSectionConcreteDataValue.I_BSCDV_BEAM_I_H);
                     b = concMember.GetValue(IRobotBarSectionConcreteDataValue.I_BSCDV_BEAM_I_B);
                     sectionProfile = BH.Engine.Geometry.Create.FabricatedISectionProfile(h, b1, b2, b, HF1, HF2, 0);
-                    return BH.Engine.Structure.Create.ConcreteSectionFromProfile(sectionProfile);
+                    break;
 
                 case IRobotBarSectionShapeType.I_BSST_CONCR_BEAM_T:
                     h = concMember.GetValue(IRobotBarSectionConcreteDataValue.I_BSCDV_BEAM_T_H);
@@ -79,13 +79,13 @@ namespace BH.Adapter.Robot
                     HF = concMember.GetValue(IRobotBarSectionConcreteDataValue.I_BSCDV_BEAM_T_HF);
                     b = concMember.GetValue(IRobotBarSectionConcreteDataValue.I_BSCDV_BEAM_T_BF);
                     sectionProfile = BH.Engine.Geometry.Create.TSectionProfile(h, b, b1, HF, 0, 0);
-                    return BH.Engine.Structure.Create.ConcreteSectionFromProfile(sectionProfile);
+                    break;
 
                 case IRobotBarSectionShapeType.I_BSST_CONCR_COL_R:
                     h = concMember.GetValue(IRobotBarSectionConcreteDataValue.I_BSCDV_COL_H);
                     b = concMember.GetValue(IRobotBarSectionConcreteDataValue.I_BSCDV_COL_B);
                     sectionProfile = BH.Engine.Geometry.Create.RectangleProfile(b, h, 0);
-                    return BH.Engine.Structure.Create.ConcreteSectionFromProfile(sectionProfile);
+                    break;
 
                 case IRobotBarSectionShapeType.I_BSST_CONCR_COL_T:
                     h = concMember.GetValue(IRobotBarSectionConcreteDataValue.I_BSCDV_COL_H);
@@ -95,12 +95,12 @@ namespace BH.Adapter.Robot
                     l1 = concMember.GetValue(IRobotBarSectionConcreteDataValue.I_BSCDV_COL_L1);
                     l2 = concMember.GetValue(IRobotBarSectionConcreteDataValue.I_BSCDV_COL_L2);
                     sectionProfile = BH.Engine.Geometry.Create.TSectionProfile(h, b, b - l1 - l2, h - h1, 0, 0);
-                    return BH.Engine.Structure.Create.ConcreteSectionFromProfile(sectionProfile);
+                    break;
 
                 case IRobotBarSectionShapeType.I_BSST_CONCR_COL_C:
                     h = concMember.GetValue(IRobotBarSectionConcreteDataValue.I_BSCDV_COL_DE);
                     sectionProfile = BH.Engine.Geometry.Create.CircleProfile(h);
-                    return BH.Engine.Structure.Create.ConcreteSectionFromProfile(sectionProfile);
+                    break;
 
                 case IRobotBarSectionShapeType.I_BSST_CONCR_COL_L:
                     h = concMember.GetValue(IRobotBarSectionConcreteDataValue.I_BSCDV_COL_H);
@@ -108,15 +108,20 @@ namespace BH.Adapter.Robot
                     h1 = concMember.GetValue(IRobotBarSectionConcreteDataValue.I_BSCDV_COL_H1);
                     l1 = concMember.GetValue(IRobotBarSectionConcreteDataValue.I_BSCDV_COL_L1);
                     sectionProfile = BH.Engine.Geometry.Create.AngleProfile(h, b, b - l1, h - h1, 0, 0);
-                    return BH.Engine.Structure.Create.ConcreteSectionFromProfile(sectionProfile);
+                    break;
 
                 default:
                     return null;
             }
 
-            /***************************************************/
+            if (sectionProfile != null)
+                return BH.Engine.Structure.Create.ConcreteSectionFromProfile(sectionProfile);
+            else
+                return null;
 
         }
+
+        /***************************************************/
     }
 }
 

--- a/Robot_Adapter/Convert/FromRobot/Properties/SectionProperty_Steel.cs
+++ b/Robot_Adapter/Convert/FromRobot/Properties/SectionProperty_Steel.cs
@@ -21,9 +21,11 @@
  */
 
 using BH.oM.Structure.MaterialFragments;
+using BH.oM.Geometry;
 using RobotOM;
 using BH.oM.Structure.SectionProperties;
 using BH.oM.Geometry.ShapeProfiles;
+using System;
 
 namespace BH.Adapter.Robot
 {
@@ -144,7 +146,12 @@ namespace BH.Adapter.Robot
                         H = nonStdData.GetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_BOX_2_H);
                         TW = nonStdData.GetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_BOX_2_TW);
                         TF = nonStdData.GetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_BOX_2_TF);
-                        sectionProfile = BH.Engine.Geometry.Create.GeneralisedFabricatedBoxProfile(H + (2 * TF), B1 + (2 * TW), TW, TF, TF, (B - B1 - (2 * TW)) / 2, (B - B1 - (2 * TW)) / 2);
+                        double outstand = (B - B1 - (2 * TW)) / 2;
+                        //Check if subtraction leads to negative "0", if so, set to zero to avoid profile method braking
+                        if (outstand < 0 && Math.Abs(outstand) < Tolerance.MicroDistance)
+                            outstand = 0;
+
+                        sectionProfile = BH.Engine.Geometry.Create.GeneralisedFabricatedBoxProfile(H + (2 * TF), B1 + (2 * TW), TW, TF, TF, outstand, outstand);
                         break;
 
                     case IRobotBarSectionShapeType.I_BSST_USER_BOX_3:
@@ -155,7 +162,18 @@ namespace BH.Adapter.Robot
                         TW = nonStdData.GetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_BOX_3_TW);
                         TF = nonStdData.GetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_BOX_3_TF);
                         TF2 = nonStdData.GetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_BOX_3_TF2);
-                        sectionProfile = BH.Engine.Geometry.Create.GeneralisedFabricatedBoxProfile(H + TF + TF2, B1 + (2 * TW), TW, TF, TF2, (B2 - B1 - (2 * TW)) / 2, (B - B1 - (2 * TW)) / 2);
+
+                        double topOutstand = (B2 - B1 - (2 * TW)) / 2;
+                        double botOutstand = (B - B1 - (2 * TW)) / 2;
+
+                        //Check if subtraction leads to negative "0", if so, set to zero to avoid profile method braking
+                        if (topOutstand < 0 && Math.Abs(topOutstand) < Tolerance.MicroDistance)
+                            topOutstand = 0;
+
+                        if (botOutstand < 0 && Math.Abs(botOutstand) < Tolerance.MicroDistance)
+                            botOutstand = 0;
+
+                        sectionProfile = BH.Engine.Geometry.Create.GeneralisedFabricatedBoxProfile(H + TF + TF2, B1 + (2 * TW), TW, TF, TF2, topOutstand, botOutstand);
                         break;
 
                     case IRobotBarSectionShapeType.I_BSST_BOX:

--- a/Robot_Adapter/Convert/FromRobot/Properties/SectionProperty_Steel.cs
+++ b/Robot_Adapter/Convert/FromRobot/Properties/SectionProperty_Steel.cs
@@ -35,7 +35,7 @@ namespace BH.Adapter.Robot
 
         public static ISectionProperty FromRobotSteelSection(IRobotBarSectionData secData)
         {
-            IProfile sectionProfile;
+            IProfile sectionProfile = null;
 
             if (secData.Type == IRobotBarSectionType.I_BST_STANDARD)
             {
@@ -57,7 +57,7 @@ namespace BH.Adapter.Robot
                     case IRobotBarSectionShapeType.I_BSST_HEB:
                     case IRobotBarSectionShapeType.I_BSST_HEC:
                         sectionProfile = BH.Engine.Geometry.Create.ISectionProfile(d, bf, Tw, Tf, r, ri);
-                        return BH.Engine.Structure.Create.SteelSectionFromProfile(sectionProfile);
+                        break;
 
                     case IRobotBarSectionShapeType.I_BSST_USER_RECT:
                     case IRobotBarSectionShapeType.I_BSST_TREC:
@@ -72,27 +72,27 @@ namespace BH.Adapter.Robot
                         {
                             sectionProfile = BH.Engine.Geometry.Create.BoxProfile(d, bf, Tf, 0, 0);
                         }
-                        return BH.Engine.Structure.Create.SteelSectionFromProfile(sectionProfile);
+                        break;
 
                     case IRobotBarSectionShapeType.I_BSST_RECT_FILLED:
                         sectionProfile = BH.Engine.Geometry.Create.RectangleProfile(d, bf, 0);
-                        return BH.Engine.Structure.Create.SteelSectionFromProfile(sectionProfile);
+                        break;
 
                     case IRobotBarSectionShapeType.I_BSST_USER_T_SHAPE:
                         sectionProfile = BH.Engine.Geometry.Create.TSectionProfile(d, bf, Tw, Tf, 0, 0);
-                        return BH.Engine.Structure.Create.SteelSectionFromProfile(sectionProfile);
+                        break;
 
                     case IRobotBarSectionShapeType.I_BSST_USER_TUBE:
                         sectionProfile = BH.Engine.Geometry.Create.TubeProfile(d, Tf);
-                        return BH.Engine.Structure.Create.SteelSectionFromProfile(sectionProfile);
+                        break;
 
                     case IRobotBarSectionShapeType.I_BSST_UPN:
                         sectionProfile = BH.Engine.Geometry.Create.ChannelProfile(d, bf, Tw, Tf, r, ri);
-                        return BH.Engine.Structure.Create.SteelSectionFromProfile(sectionProfile);
+                        break;
 
                     case IRobotBarSectionShapeType.I_BSST_CAE:
                         sectionProfile = BH.Engine.Geometry.Create.AngleProfile(d, bf, Tw, Tf, r, ri);
-                        return BH.Engine.Structure.Create.SteelSectionFromProfile(sectionProfile);
+                        break;
                     default:
                         return null;
                 }
@@ -122,13 +122,13 @@ namespace BH.Adapter.Robot
                         T = nonStdData.GetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_TUBE_T);
                         D = nonStdData.GetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_TUBE_D);
                         sectionProfile = BH.Engine.Geometry.Create.TubeProfile(D, T);
-                        return BH.Engine.Structure.Create.SteelSectionFromProfile(sectionProfile);
+                        break;
 
                     case IRobotBarSectionShapeType.I_BSST_USER_RECT:
                         B = nonStdData.GetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_RECT_B);
                         H = nonStdData.GetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_RECT_H);
                         sectionProfile = BH.Engine.Geometry.Create.RectangleProfile(H, B, 0);
-                        return BH.Engine.Structure.Create.SteelSectionFromProfile(sectionProfile);
+                        break;
 
                     case IRobotBarSectionShapeType.I_BSST_USER_I_BISYM:
                         B = nonStdData.GetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_I_B);
@@ -136,7 +136,7 @@ namespace BH.Adapter.Robot
                         TW = nonStdData.GetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_I_TW);
                         TF = nonStdData.GetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_I_TF);
                         sectionProfile = BH.Engine.Geometry.Create.ISectionProfile(H + (2 * TF), B, TW, TF, 0, 0);
-                        return BH.Engine.Structure.Create.SteelSectionFromProfile(sectionProfile);
+                        break;
 
                     case IRobotBarSectionShapeType.I_BSST_USER_BOX_2:
                         B = nonStdData.GetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_BOX_2_B);
@@ -145,7 +145,7 @@ namespace BH.Adapter.Robot
                         TW = nonStdData.GetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_BOX_2_TW);
                         TF = nonStdData.GetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_BOX_2_TF);
                         sectionProfile = BH.Engine.Geometry.Create.GeneralisedFabricatedBoxProfile(H + (2 * TF), B1 + (2 * TW), TW, TF, TF, (B - B1 - (2 * TW)) / 2, (B - B1 - (2 * TW)) / 2);
-                        return BH.Engine.Structure.Create.SteelSectionFromProfile(sectionProfile);
+                        break;
 
                     case IRobotBarSectionShapeType.I_BSST_USER_BOX_3:
                         B = nonStdData.GetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_BOX_3_B);
@@ -156,7 +156,7 @@ namespace BH.Adapter.Robot
                         TF = nonStdData.GetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_BOX_3_TF);
                         TF2 = nonStdData.GetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_BOX_3_TF2);
                         sectionProfile = BH.Engine.Geometry.Create.GeneralisedFabricatedBoxProfile(H + TF + TF2, B1 + (2 * TW), TW, TF, TF2, (B2 - B1 - (2 * TW)) / 2, (B - B1 - (2 * TW)) / 2);
-                        return BH.Engine.Structure.Create.SteelSectionFromProfile(sectionProfile);
+                        break;
 
                     case IRobotBarSectionShapeType.I_BSST_BOX:
                         B = nonStdData.GetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_BOX_B);
@@ -165,24 +165,31 @@ namespace BH.Adapter.Robot
                         TF = nonStdData.GetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_BOX_TF);
 
                         sectionProfile = BH.Engine.Geometry.Create.FabricatedBoxProfile(H + (2 * TF), B, TW, TF, TF, 0);
-                        return BH.Engine.Structure.Create.SteelSectionFromProfile(sectionProfile);
+                        break;
 
                     case IRobotBarSectionShapeType.I_BSST_USER_I_MONOSYM:
-                        B = nonStdData.GetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_II_B1);
+                        B1 = nonStdData.GetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_II_B1);
+                        B2 = nonStdData.GetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_II_B2);
                         H = nonStdData.GetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_II_H);
                         TW = nonStdData.GetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_II_TW);
                         TF = nonStdData.GetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_II_TF1);
-                        sectionProfile = BH.Engine.Geometry.Create.ISectionProfile(H + (2 * TF), B, TW, TF, 0, 0);
-                        return BH.Engine.Structure.Create.SteelSectionFromProfile(sectionProfile);
+                        TF2 = nonStdData.GetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_II_TF2);
+                        sectionProfile = BH.Engine.Geometry.Create.FabricatedISectionProfile(H + TF + TF2, B1, B2, TW, TF, TF2, 0);
+                        break;
 
                     case IRobotBarSectionShapeType.I_BSST_USER_CIRC_FILLED:
                         sectionProfile = BH.Engine.Geometry.Create.CircleProfile(D);
-                        return BH.Engine.Structure.Create.SteelSectionFromProfile(sectionProfile);
+                        break;
 
                     default:
                         return null;
                 }
             }
+
+            if (sectionProfile != null)
+                return BH.Engine.Structure.Create.SteelSectionFromProfile(sectionProfile);
+            else
+                return null;
         }
 
         /***************************************************/


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->


 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #326 
Closes #327 
Closes #328 

 <!-- Add short description of what has been fixed -->


 ### Test files
<!-- Link to test files to validate the proposed changes -->

https://burohappold.sharepoint.com/:f:/s/BHoM/EsbJnBc3aV1IoxOgZtF-AngBQQU67kiEDeeAJ5N9xD5iYw?e=oBX72p

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->

- Checking if profile is null before generating section to avoid unhandled crash
- Fixing bug for Monosymmetric I-section comming out as double symmetric
- Adding check for Corbel width, if subtraction during extraction leads to tiny negative values.

 ### Additional comments
<!-- As required -->
