### PR TITLE
Fixing pull push fail due to null framing element properties

### DIFF
--- a/Robot_Adapter/CRUD/Create/Elements/Bars.cs
+++ b/Robot_Adapter/CRUD/Create/Elements/Bars.cs
@@ -88,17 +88,20 @@ namespace BH.Adapter.Robot
                     if (bhomBar.CustomData.ContainsKey("FramingElementDesignProperties"))
                     {
                         FramingElementDesignProperties framEleDesProps = bhomBar.CustomData["FramingElementDesignProperties"] as FramingElementDesignProperties;
-                        if (m_RobotApplication.Project.Structure.Labels.Exist(IRobotLabelType.I_LT_MEMBER_TYPE, framEleDesProps.Name)!=-1)
+                        if (framEleDesProps != null)
                         {
-                            Create(framEleDesProps);
+                            if (m_RobotApplication.Project.Structure.Labels.Exist(IRobotLabelType.I_LT_MEMBER_TYPE, framEleDesProps.Name) != -1)
+                            {
+                                Create(framEleDesProps);
+                            }
+                            else
+                            {
+                                List<FramingElementDesignProperties> framEleDesPropsList = new List<FramingElementDesignProperties>();
+                                framEleDesPropsList.Add(framEleDesProps);
+                                Update(framEleDesPropsList);
+                            }
+                            rcache.SetBarLabel(barNum, IRobotLabelType.I_LT_MEMBER_TYPE, framEleDesProps.Name);
                         }
-                        else
-                        {
-                            List<FramingElementDesignProperties> framEleDesPropsList = new List<FramingElementDesignProperties>();
-                            framEleDesPropsList.Add(framEleDesProps);
-                            Update(framEleDesPropsList);
-                        }
-                        rcache.SetBarLabel(barNum, IRobotLabelType.I_LT_MEMBER_TYPE, framEleDesProps.Name);
                     }                  
 
 

--- a/Robot_Adapter/Convert/FromRobot/Elements/Bar.cs
+++ b/Robot_Adapter/Convert/FromRobot/Elements/Bar.cs
@@ -125,7 +125,7 @@ namespace BH.Adapter.Robot
                 string framEleDesPropsName = robotBar.GetLabelName(IRobotLabelType.I_LT_MEMBER_TYPE);
                 if (bhomFramEleDesPropList.TryGetValue(framEleDesPropsName, out bhomFramEleDesignProps) && bhomFramEleDesignProps != null)
                 {
-                    bhomBar.CustomData.Add("FramingElementDesignProperties", bhomFramEleDesignProps);
+                    bhomBar.CustomData["FramingElementDesignProperties"] = bhomFramEleDesignProps;
                 }
                 else
                 { 
@@ -147,7 +147,6 @@ namespace BH.Adapter.Robot
             bhomBar.SectionProperty = secProp;
             bhomBar.OrientationAngle = robotBar.Gamma * Math.PI / 180;
             bhomBar.CustomData[AdapterID] = robotBar.Number;
-            bhomBar.CustomData["FramingElementDesignProperties"] = bhomFramEleDesignProps;
 
             if (robotBar.TensionCompression == IRobotBarTensionCompression.I_BTC_COMPRESSION_ONLY)
             {

--- a/Robot_Adapter/Convert/FromRobot/Elements/Bar.cs
+++ b/Robot_Adapter/Convert/FromRobot/Elements/Bar.cs
@@ -123,7 +123,7 @@ namespace BH.Adapter.Robot
             if (robotBar.HasLabel(IRobotLabelType.I_LT_MEMBER_TYPE) == -1)
             {
                 string framEleDesPropsName = robotBar.GetLabelName(IRobotLabelType.I_LT_MEMBER_TYPE);
-                if (bhomFramEleDesPropList.TryGetValue(framEleDesPropsName, out bhomFramEleDesignProps))
+                if (bhomFramEleDesPropList.TryGetValue(framEleDesPropsName, out bhomFramEleDesignProps) && bhomFramEleDesignProps != null)
                 {
                     bhomBar.CustomData.Add("FramingElementDesignProperties", bhomFramEleDesignProps);
                 }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #331 

 <!-- Add short description of what has been fixed -->

Adding null check for design properties when converting to and from Robot.

 ### Test files
<!-- Link to test files to validate the proposed changes -->

https://burohappold.sharepoint.com/:u:/s/BHoM/EYsw6wUKmEZLidWk9pRKG3YBmx-YRP0Xzjw2btaG7hVY6Q?e=giu4A4
 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->
