### PR TITLE
Pull area loads from Robot

### DIFF
--- a/Robot_Adapter/CRUD/Read/Loads/AreaUniformlyDistributedLoad.cs
+++ b/Robot_Adapter/CRUD/Read/Loads/AreaUniformlyDistributedLoad.cs
@@ -1,0 +1,108 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using BH.oM.Structure.Elements;
+using RobotOM;
+using BH.oM.Geometry;
+using BH.oM.Base;
+using BH.oM.Structure.Loads;
+using BH.oM.Adapters.Robot;
+
+
+namespace BH.Adapter.Robot
+{
+    public partial class RobotAdapter
+    {
+        /***************************************************/
+        /****           Private Methods                 ****/
+        /***************************************************/
+
+        private List<ILoad> ReadAreaUniformlyDistributedLoad(List<string> ids = null)
+        {
+            List<ILoad> bhomLoads = new List<ILoad>();
+            Dictionary<int, Panel> bhomPanel = ReadPanels().ToDictionary(x => System.Convert.ToInt32(x.CustomData[AdapterIdName]));
+            Dictionary<string, Loadcase> bhomLoadCases = new Dictionary<string, Loadcase>();
+            List<Loadcase> lCases = ReadLoadCase();
+            for (int i = 0; i < lCases.Count; i++)
+            {
+                if (!bhomLoadCases.ContainsKey(lCases[i].Name))
+                    bhomLoadCases.Add(lCases[i].Name, lCases[i]);
+            }
+
+            //Dictionary<string, Loadcase> bhomLoadCases = ReadLoadCase().ToDictionary(x => x.Name);
+            IRobotCaseCollection loadCollection = m_RobotApplication.Project.Structure.Cases.GetAll();
+
+            for (int i = 1; i <= loadCollection.Count; i++)
+            {
+                IRobotCase lCase = loadCollection.Get(i) as IRobotCase;
+                if (lCase.Type == IRobotCaseType.I_CT_SIMPLE)
+                {
+                    IRobotSimpleCase sCase = lCase as IRobotSimpleCase;
+                    if (bhomLoadCases.ContainsKey(sCase.Name))
+                    {
+                        for (int j = 1; j <= sCase.Records.Count; j++)
+                        {
+                            IRobotLoadRecord loadRecord = sCase.Records.Get(j);
+                            List<int> elementIds = Convert.FromRobotSelectionString(loadRecord.Objects.ToText());
+                            List<Panel> objects = new List<Panel>();
+                            for (int k = 0; k < elementIds.Count; k++)
+                            {
+                                if (bhomPanel.ContainsKey(elementIds[k]))
+                                    objects.Add(bhomPanel[elementIds[k]]);
+                            }
+
+                            switch (loadRecord.Type)
+                            {
+                                case IRobotLoadRecordType.I_LRT_UNIFORM:
+                                    double fx = loadRecord.GetValue((short)IRobotUniformRecordValues.I_URV_PX);
+                                    double fy = loadRecord.GetValue((short)IRobotUniformRecordValues.I_URV_PY);
+                                    double fz = loadRecord.GetValue((short)IRobotUniformRecordValues.I_URV_PZ);
+                                    double ls = loadRecord.GetValue((short)IRobotUniformRecordValues.I_URV_LOCAL_SYSTEM);
+                                    double pj = loadRecord.GetValue((short)IRobotUniformRecordValues.I_URV_PROJECTED);
+
+
+                                    AreaUniformlyDistributedLoad PanelPressure = new AreaUniformlyDistributedLoad
+                                    {
+                                        Pressure = new Vector { X = fx, Y = fy, Z = fz },
+                                        Loadcase = bhomLoadCases[sCase.Name],
+                                        Objects = new BHoMGroup<IAreaElement>() { Elements = objects.ToList<IAreaElement>() },
+                                        Axis = ls == 0 ? LoadAxis.Global : LoadAxis.Local,
+                                        Projected = pj == 1
+                                    };
+                                    bhomLoads.Add(PanelPressure);
+                                    break;
+                            }
+                        }
+                    }
+                }
+            }
+            return bhomLoads;
+        }
+
+        /***************************************************/
+
+    }
+
+}

--- a/Robot_Adapter/CRUD/Read/Loads/Loads.cs
+++ b/Robot_Adapter/CRUD/Read/Loads/Loads.cs
@@ -269,7 +269,7 @@ namespace BH.Adapter.Robot
             List<Loadcase> lCases = ReadLoadCase();
             for (int i = 0; i < lCases.Count; i++)
             {
-                if (bhomLoadCases.ContainsKey(lCases[i].Name) == false)
+                if (!bhomLoadCases.ContainsKey(lCases[i].Name))
                     bhomLoadCases.Add(lCases[i].Name, lCases[i]);
             }
 
@@ -309,7 +309,7 @@ namespace BH.Adapter.Robot
                                     {
                                         Pressure = new Vector { X = fx, Y = fy, Z = fz },
                                         Loadcase = bhomLoadCases[sCase.Name],
-                                        Objects = BH.Engine.Base.Create.BHoMGroup(objects) as BHoMGroup<IAreaElement>,
+                                        Objects = new BHoMGroup<IAreaElement>() { Elements = objects.ToList<IAreaElement>() },
                                         Axis = ls == 0 ? LoadAxis.Global : LoadAxis.Local,
                                         Projected = pj == 1
                                     };

--- a/Robot_Adapter/CRUD/Read/Loads/Loads.cs
+++ b/Robot_Adapter/CRUD/Read/Loads/Loads.cs
@@ -47,7 +47,8 @@ namespace BH.Adapter.Robot
                 return ReadContourLoads(ids);
             else if (type == typeof(oM.Structure.Loads.GeometricalLineLoad) || type == typeof(oM.Adapters.Robot.GeometricalLineLoad))
                 return ReadGeometricalLineLoads(ids);
-
+            else if (type == typeof(oM.Structure.Loads.AreaUniformlyDistributedLoad))
+                return ReadAreaUniformlyDistributedLoad(ids);
             return new List<ILoad>();
         }
 
@@ -256,6 +257,71 @@ namespace BH.Adapter.Robot
             return bhomLoads;
         }
 
+
+        /***************************************************/
+
+
+        private List<ILoad> ReadAreaUniformlyDistributedLoad(List<string> ids = null)
+        {
+            List<ILoad> bhomLoads = new List<ILoad>();
+            Dictionary<int, Panel> bhomPanel = ReadPanels().ToDictionary(x => System.Convert.ToInt32(x.CustomData[AdapterIdName]));
+            Dictionary<string, Loadcase> bhomLoadCases = new Dictionary<string, Loadcase>();
+            List<Loadcase> lCases = ReadLoadCase();
+            for (int i = 0; i < lCases.Count; i++)
+            {
+                if (bhomLoadCases.ContainsKey(lCases[i].Name) == false)
+                    bhomLoadCases.Add(lCases[i].Name, lCases[i]);
+            }
+
+            //Dictionary<string, Loadcase> bhomLoadCases = ReadLoadCase().ToDictionary(x => x.Name);
+            IRobotCaseCollection loadCollection = m_RobotApplication.Project.Structure.Cases.GetAll();
+
+            for (int i = 1; i <= loadCollection.Count; i++)
+            {
+                IRobotCase lCase = loadCollection.Get(i) as IRobotCase;
+                if (lCase.Type == IRobotCaseType.I_CT_SIMPLE)
+                {
+                    IRobotSimpleCase sCase = lCase as IRobotSimpleCase;
+                    if (bhomLoadCases.ContainsKey(sCase.Name))
+                    {
+                        for (int j = 1; j <= sCase.Records.Count; j++)
+                        {
+                            IRobotLoadRecord loadRecord = sCase.Records.Get(j);
+                            List<int> elementIds = Convert.FromRobotSelectionString(loadRecord.Objects.ToText());
+                            List<Panel> objects = new List<Panel>();
+                            for (int k = 0; k < elementIds.Count; k++)
+                            {
+                                if (bhomPanel.ContainsKey(elementIds[k]))
+                                    objects.Add(bhomPanel[elementIds[k]]);
+                            }
+
+                            switch (loadRecord.Type)
+                            {
+                                case IRobotLoadRecordType.I_LRT_UNIFORM:
+                                    double fx = loadRecord.GetValue((short)IRobotUniformRecordValues.I_URV_PX);
+                                    double fy = loadRecord.GetValue((short)IRobotUniformRecordValues.I_URV_PY);
+                                    double fz = loadRecord.GetValue((short)IRobotUniformRecordValues.I_URV_PZ);
+                                    double ls = loadRecord.GetValue((short)IRobotUniformRecordValues.I_URV_LOCAL_SYSTEM);
+                                    double pj = loadRecord.GetValue((short)IRobotUniformRecordValues.I_URV_PROJECTED);
+
+
+                                    AreaUniformlyDistributedLoad PanelPressure = new AreaUniformlyDistributedLoad
+                                    {
+                                        Pressure = new Vector { X = fx, Y = fy, Z = fz },
+                                        Loadcase = bhomLoadCases[sCase.Name],
+                                        Objects = BH.Engine.Base.Create.BHoMGroup(objects) as BHoMGroup<IAreaElement>,
+                                        Axis = ls == 0 ? LoadAxis.Global : LoadAxis.Local,
+                                        Projected = pj == 1
+                                    };
+                                    bhomLoads.Add(PanelPressure);
+                                    break;
+                            }
+                        }
+                    }
+                }
+            }
+            return bhomLoads;
+        }
 
         /***************************************************/
 

--- a/Robot_Adapter/CRUD/Read/Loads/Loads.cs
+++ b/Robot_Adapter/CRUD/Read/Loads/Loads.cs
@@ -261,69 +261,6 @@ namespace BH.Adapter.Robot
         /***************************************************/
 
 
-        private List<ILoad> ReadAreaUniformlyDistributedLoad(List<string> ids = null)
-        {
-            List<ILoad> bhomLoads = new List<ILoad>();
-            Dictionary<int, Panel> bhomPanel = ReadPanels().ToDictionary(x => System.Convert.ToInt32(x.CustomData[AdapterIdName]));
-            Dictionary<string, Loadcase> bhomLoadCases = new Dictionary<string, Loadcase>();
-            List<Loadcase> lCases = ReadLoadCase();
-            for (int i = 0; i < lCases.Count; i++)
-            {
-                if (!bhomLoadCases.ContainsKey(lCases[i].Name))
-                    bhomLoadCases.Add(lCases[i].Name, lCases[i]);
-            }
-
-            //Dictionary<string, Loadcase> bhomLoadCases = ReadLoadCase().ToDictionary(x => x.Name);
-            IRobotCaseCollection loadCollection = m_RobotApplication.Project.Structure.Cases.GetAll();
-
-            for (int i = 1; i <= loadCollection.Count; i++)
-            {
-                IRobotCase lCase = loadCollection.Get(i) as IRobotCase;
-                if (lCase.Type == IRobotCaseType.I_CT_SIMPLE)
-                {
-                    IRobotSimpleCase sCase = lCase as IRobotSimpleCase;
-                    if (bhomLoadCases.ContainsKey(sCase.Name))
-                    {
-                        for (int j = 1; j <= sCase.Records.Count; j++)
-                        {
-                            IRobotLoadRecord loadRecord = sCase.Records.Get(j);
-                            List<int> elementIds = Convert.FromRobotSelectionString(loadRecord.Objects.ToText());
-                            List<Panel> objects = new List<Panel>();
-                            for (int k = 0; k < elementIds.Count; k++)
-                            {
-                                if (bhomPanel.ContainsKey(elementIds[k]))
-                                    objects.Add(bhomPanel[elementIds[k]]);
-                            }
-
-                            switch (loadRecord.Type)
-                            {
-                                case IRobotLoadRecordType.I_LRT_UNIFORM:
-                                    double fx = loadRecord.GetValue((short)IRobotUniformRecordValues.I_URV_PX);
-                                    double fy = loadRecord.GetValue((short)IRobotUniformRecordValues.I_URV_PY);
-                                    double fz = loadRecord.GetValue((short)IRobotUniformRecordValues.I_URV_PZ);
-                                    double ls = loadRecord.GetValue((short)IRobotUniformRecordValues.I_URV_LOCAL_SYSTEM);
-                                    double pj = loadRecord.GetValue((short)IRobotUniformRecordValues.I_URV_PROJECTED);
-
-
-                                    AreaUniformlyDistributedLoad PanelPressure = new AreaUniformlyDistributedLoad
-                                    {
-                                        Pressure = new Vector { X = fx, Y = fy, Z = fz },
-                                        Loadcase = bhomLoadCases[sCase.Name],
-                                        Objects = new BHoMGroup<IAreaElement>() { Elements = objects.ToList<IAreaElement>() },
-                                        Axis = ls == 0 ? LoadAxis.Global : LoadAxis.Local,
-                                        Projected = pj == 1
-                                    };
-                                    bhomLoads.Add(PanelPressure);
-                                    break;
-                            }
-                        }
-                    }
-                }
-            }
-            return bhomLoads;
-        }
-
-        /***************************************************/
 
     }
 

--- a/Robot_Adapter/Robot_Adapter.csproj
+++ b/Robot_Adapter/Robot_Adapter.csproj
@@ -212,6 +212,7 @@
     <Compile Include="CRUD\Create\Create.cs" />
     <Compile Include="AdapterActions\Execute.cs" />
     <Compile Include="CRUD\Read\Loads\LoadCombinations.cs" />
+    <Compile Include="CRUD\Read\Loads\AreaUniformlyDistributedLoad.cs" />
     <Compile Include="CRUD\Read\Properties\Labels.cs" />
     <Compile Include="CRUD\Read\Properties\LinearReleases.cs" />
     <Compile Include="CRUD\Update\Elements\Nodes.cs" />


### PR DESCRIPTION
Re-commit from new master branch to account for refactoring and other changes.

<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->
Panel area loads in Robot are not pulled from Robot adaptor.
Closes #294
Uniformly distributed area load can now be pulled from Robot.

 <!-- Add short description of what has been fixed -->


 ### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FRobot%5FToolkit%2FPull%20Requests%2FPull%20Panel%20Area%20Loads

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
Load is read as AreaUniformlyDistributedLoad
Key components -> Vector ; Projected ; Axis

 ### Additional comments
<!-- As required -->
