### PR TITLE
Make use of new DescriptionOrName method and comparer

### DIFF
--- a/Robot_Adapter/CRUD/Create/Elements/Bars.cs
+++ b/Robot_Adapter/CRUD/Create/Elements/Bars.cs
@@ -26,6 +26,7 @@ using System;
 using BH.oM.Structure.Elements;
 using RobotOM;
 using BH.oM.Adapters.Robot;
+using BH.Engine.Structure;
 
 namespace BH.Adapter.Robot
 {
@@ -68,9 +69,9 @@ namespace BH.Adapter.Robot
                         sectionName = Convert.Match(m_dbSecPropNames, bhomBar.SectionProperty);
                         materialName = Convert.Match(m_dbMaterialNames, bhomBar.SectionProperty.Material);
                         if (sectionName == null)
-                            sectionName = bhomBar.SectionProperty.Name;
+                            sectionName = bhomBar.SectionProperty.DescriptionOrName();
                         if (materialName == null)
-                            materialName = bhomBar.SectionProperty.Material.Name;
+                            materialName = bhomBar.SectionProperty.Material.DescriptionOrName();
                     }
                     rcache.AddBar(barNum,
                                   System.Convert.ToInt32(bhomBar.StartNode.CustomData[AdapterIdName]),
@@ -80,7 +81,7 @@ namespace BH.Adapter.Robot
                                   bhomBar.OrientationAngle * 180 / Math.PI);
 
                     if (bhomBar.Release != null)
-                        rcache.SetBarLabel(barNum, IRobotLabelType.I_LT_BAR_RELEASE, bhomBar.Release.Name);
+                        rcache.SetBarLabel(barNum, IRobotLabelType.I_LT_BAR_RELEASE, bhomBar.Release.DescriptionOrName());
                     else
                         Engine.Reflection.Compute.RecordWarning("Bar with id " + barNum + " did not have any release assigned. Default in Robot will be used");
 

--- a/Robot_Adapter/CRUD/Create/Elements/FEMeshes.cs
+++ b/Robot_Adapter/CRUD/Create/Elements/FEMeshes.cs
@@ -26,6 +26,7 @@ using System.Linq;
 using System;
 using BH.oM.Structure.Elements;
 using BH.oM.Structure.SurfaceProperties;
+using BH.Engine.Structure;
 using RobotOM;
 
 namespace BH.Adapter.Robot
@@ -86,10 +87,10 @@ namespace BH.Adapter.Robot
                 objServer.Objects.CreateOnFiniteElems(faceList, elemNumber);
                 mesh = objServer.Objects.Get(elemNumber) as RobotObjObject;
                 if (fEMesh.Property is LoadingPanelProperty)
-                    mesh.SetLabel(IRobotLabelType.I_LT_CLADDING, fEMesh.Property.Name);
+                    mesh.SetLabel(IRobotLabelType.I_LT_CLADDING, fEMesh.Property.DescriptionOrName());
 
                 else
-                    mesh.SetLabel(IRobotLabelType.I_LT_PANEL_THICKNESS, fEMesh.Property.Name);
+                    mesh.SetLabel(IRobotLabelType.I_LT_PANEL_THICKNESS, fEMesh.Property.DescriptionOrName());
             }
 
             return true;

--- a/Robot_Adapter/CRUD/Create/Elements/Nodes.cs
+++ b/Robot_Adapter/CRUD/Create/Elements/Nodes.cs
@@ -23,6 +23,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using BH.oM.Structure.Elements;
+using BH.Engine.Structure;
 using RobotOM;
 
 namespace BH.Adapter.Robot
@@ -35,7 +36,7 @@ namespace BH.Adapter.Robot
 
         /***************************************************/
 
-        private bool CreateCollection(IEnumerable<BH.oM.Structure.Elements.Node> nodes)
+        private bool CreateCollection(IEnumerable<Node> nodes)
         {
             if (nodes != null)
             {
@@ -63,7 +64,7 @@ namespace BH.Adapter.Robot
                     nodeTags[nodeNum] = node.Tags;
 
                     if (node.Support != null)
-                        robotNodeCol.Get(nodeNum).SetLabel(IRobotLabelType.I_LT_SUPPORT, node.Support.Name);
+                        robotNodeCol.Get(nodeNum).SetLabel(IRobotLabelType.I_LT_SUPPORT, node.Support.DescriptionOrName());
 
                 }
 

--- a/Robot_Adapter/CRUD/Create/Elements/Panels.cs
+++ b/Robot_Adapter/CRUD/Create/Elements/Panels.cs
@@ -27,6 +27,7 @@ using BH.oM.Geometry;
 using BH.oM.Structure.SurfaceProperties;
 using RobotOM;
 using BHEG = BH.Engine.Geometry;
+using BH.Engine.Structure;
 using BH.oM.Structure.Constraints;
 using BH.Engine.Robot;
 using BH.Engine.Spatial;
@@ -63,7 +64,7 @@ namespace BH.Adapter.Robot
                 if (panel.Property is LoadingPanelProperty)
                     robotPanel.SetLabel(IRobotLabelType.I_LT_CLADDING, (panel.Property as LoadingPanelProperty).ToRobot());
                 else
-                    robotPanel.SetLabel(IRobotLabelType.I_LT_PANEL_THICKNESS, panel.Property.Name);
+                    robotPanel.SetLabel(IRobotLabelType.I_LT_PANEL_THICKNESS, panel.Property.DescriptionOrName());
 
                 RobotSelection rPanelOpenings = m_RobotApplication.Project.Structure.Selections.Create(IRobotObjectType.I_OT_OBJECT);
 
@@ -135,10 +136,10 @@ namespace BH.Adapter.Robot
                 IRobotObjEdge panelEdge = panelEdges.Get(i);
                 Constraint6DOF support = edges[i - 1].Support;
                 if (support != null)
-                    panelEdge.SetLabel(IRobotLabelType.I_LT_SUPPORT, support.Name);
+                    panelEdge.SetLabel(IRobotLabelType.I_LT_SUPPORT, support.DescriptionOrName());
                 Constraint4DOF release = edges[i - 1].Release;
                 if (release != null)
-                    m_RobotApplication.Project.Structure.Objects.LinearReleases.Set(panel.Number, i, panel.Number, 1, release.Name);
+                    m_RobotApplication.Project.Structure.Objects.LinearReleases.Set(panel.Number, i, panel.Number, 1, release.DescriptionOrName());
             }
         }
 

--- a/Robot_Adapter/CRUD/Create/Properties/BarReleases.cs
+++ b/Robot_Adapter/CRUD/Create/Properties/BarReleases.cs
@@ -22,6 +22,7 @@
 
 using System.Collections.Generic;
 using BH.oM.Structure.Constraints;
+using BH.Engine.Structure;
 using RobotOM;
 
 namespace BH.Adapter.Robot
@@ -42,7 +43,7 @@ namespace BH.Adapter.Robot
             {
                 Convert.ToRobot(robotLabelData.StartNode, release.StartRelease);
                 Convert.ToRobot(robotLabelData.EndNode, release.EndRelease);
-                robotLabelServer.StoreWithName(robotLabel, release.Name);
+                robotLabelServer.StoreWithName(robotLabel, release.DescriptionOrName());
             }
             return true;
         }

--- a/Robot_Adapter/CRUD/Create/Properties/LinearReleases.cs
+++ b/Robot_Adapter/CRUD/Create/Properties/LinearReleases.cs
@@ -24,6 +24,7 @@ using BH.Engine.Robot;
 using BH.oM.Structure.Constraints;
 using RobotOM;
 using System.Collections.Generic;
+using BH.Engine.Structure;
 
 namespace BH.Adapter.Robot
 {
@@ -44,7 +45,7 @@ namespace BH.Adapter.Robot
             foreach (Constraint4DOF linearRelease in linearReleases)
             {
                 Convert.ToRobot(robotLabel.Data, linearRelease);
-                robotLabelServer.StoreWithName(robotLabel, linearRelease.Name);
+                robotLabelServer.StoreWithName(robotLabel, linearRelease.DescriptionOrName());
             }
             return true;
         }

--- a/Robot_Adapter/CRUD/Create/Properties/LinkConstraints.cs
+++ b/Robot_Adapter/CRUD/Create/Properties/LinkConstraints.cs
@@ -23,6 +23,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using BH.oM.Structure.Constraints;
+using BH.Engine.Structure;
 using RobotOM;
 
 namespace BH.Adapter.Robot
@@ -32,8 +33,6 @@ namespace BH.Adapter.Robot
 
         /***************************************************/
         /****           Private Methods                 ****/
-        /***************************************************/
-
         /***************************************************/
 
         private bool CreateCollection(IEnumerable<LinkConstraint> linkConstraints)
@@ -50,7 +49,7 @@ namespace BH.Adapter.Robot
                 rLinkData.RY = lConst.YYtoYY;
                 rLinkData.RZ = lConst.ZZtoZZ;
 
-                m_RobotApplication.Project.Structure.Labels.StoreWithName(rigidLink, lConst.Name);
+                m_RobotApplication.Project.Structure.Labels.StoreWithName(rigidLink, lConst.DescriptionOrName());
             }
             return true;
         }

--- a/Robot_Adapter/CRUD/Create/Properties/Materials.cs
+++ b/Robot_Adapter/CRUD/Create/Properties/Materials.cs
@@ -22,6 +22,7 @@
 
 using System.Collections.Generic;
 using BH.oM.Structure.MaterialFragments;
+using BH.Engine.Structure;
 using RobotOM;
 
 namespace BH.Adapter.Robot
@@ -52,10 +53,11 @@ namespace BH.Adapter.Robot
                 }
                 else
                 {
-                    if (robotLabelServer.Exist(IRobotLabelType.I_LT_MATERIAL, material.Name) == -1)
-                        MaterialExistsWarning(material.Name);
+                    string name = material.DescriptionOrName();
+                    if (robotLabelServer.Exist(IRobotLabelType.I_LT_MATERIAL, name) == -1)
+                        MaterialExistsWarning(name);
                     Convert.ToRobot(matData, material);
-                    m_RobotApplication.Project.Structure.Labels.StoreWithName(label, material.Name);
+                    m_RobotApplication.Project.Structure.Labels.StoreWithName(label, name);
                 }
             }
             return true;

--- a/Robot_Adapter/CRUD/Create/Properties/SectionProperties.cs
+++ b/Robot_Adapter/CRUD/Create/Properties/SectionProperties.cs
@@ -22,6 +22,7 @@
 
 using System.Collections.Generic;
 using BH.oM.Structure.SectionProperties;
+using BH.Engine.Structure;
 using RobotOM;
 
 namespace BH.Adapter.Robot
@@ -54,7 +55,7 @@ namespace BH.Adapter.Robot
 
                 else
                 {
-                    label = m_RobotApplication.Project.Structure.Labels.Create(IRobotLabelType.I_LT_BAR_SECTION, p.Name);
+                    label = m_RobotApplication.Project.Structure.Labels.Create(IRobotLabelType.I_LT_BAR_SECTION, p.DescriptionOrName());
                     secData = label.Data;
                     Convert.ToRobot(p, secData);
                     m_RobotApplication.Project.Structure.Labels.Store(label);

--- a/Robot_Adapter/CRUD/Create/Properties/Supports.cs
+++ b/Robot_Adapter/CRUD/Create/Properties/Supports.cs
@@ -23,6 +23,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using BH.oM.Structure.Constraints;
+using BH.Engine.Structure;
 using RobotOM;
 using BH.Engine.Robot;
 
@@ -45,7 +46,7 @@ namespace BH.Adapter.Robot
             foreach (Constraint6DOF constraint in constraints)
             {
                 Convert.ToRobot(robotLabel.Data, constraint);
-                robotLabelServer.StoreWithName(robotLabel, constraint.Name);
+                robotLabelServer.StoreWithName(robotLabel, constraint.DescriptionOrName());
             }
             return true;
         }

--- a/Robot_Adapter/CRUD/Create/Properties/SurfaceProperties.cs
+++ b/Robot_Adapter/CRUD/Create/Properties/SurfaceProperties.cs
@@ -22,6 +22,7 @@
 
 using System.Collections.Generic;
 using BH.oM.Structure.SurfaceProperties;
+using BH.Engine.Structure;
 using RobotOM;
 
 namespace BH.Adapter.Robot
@@ -41,13 +42,13 @@ namespace BH.Adapter.Robot
                 {
                     IRobotLabel robotLabel = robotLabelServer.Create(IRobotLabelType.I_LT_CLADDING, "");
                     Convert.ToRobot(robotLabel, property);
-                    robotLabelServer.StoreWithName(robotLabel, property.Name);
+                    robotLabelServer.StoreWithName(robotLabel, property.DescriptionOrName());
                 }
                 else
                 {
                     IRobotLabel robotLabel = robotLabelServer.Create(IRobotLabelType.I_LT_PANEL_THICKNESS, "");
                     Convert.ToRobot(robotLabel, property);
-                    robotLabelServer.StoreWithName(robotLabel, property.Name);
+                    robotLabelServer.StoreWithName(robotLabel, property.DescriptionOrName());
                 }
             }
             return true;

--- a/Robot_Adapter/Convert/ToRobot/Properties/SectionProperty.cs
+++ b/Robot_Adapter/Convert/ToRobot/Properties/SectionProperty.cs
@@ -43,7 +43,7 @@ namespace BH.Adapter.Robot
 
         public static void ToRobot(this ExplicitSection section, IMaterialFragment material, IRobotBarSectionData secData)
         {
-            secData.MaterialName = material.Name;
+            secData.MaterialName = material.DescriptionOrName();
 
             secData.SetValue(IRobotBarSectionDataValue.I_BSDV_AX, section.Area);
             secData.SetValue(IRobotBarSectionDataValue.I_BSDV_IX, section.J);
@@ -61,7 +61,7 @@ namespace BH.Adapter.Robot
 
         public static void ToRobot(this ISectionProperty section, IMaterialFragment material, IRobotBarSectionData secData)
         {
-            secData.MaterialName = material.Name;
+            secData.MaterialName = material.DescriptionOrName();
             Engine.Reflection.Compute.RecordWarning("Section of type " + section.GetType().Name + " is not yet supported in the Robot adapter. Section with name " + secData.Name + " will not have any properties set");
         }
         

--- a/Robot_Adapter/Convert/ToRobot/Properties/SectionProperty_Concrete.cs
+++ b/Robot_Adapter/Convert/ToRobot/Properties/SectionProperty_Concrete.cs
@@ -21,6 +21,7 @@
  */
 
 using BH.oM.Structure.MaterialFragments;
+using BH.Engine.Structure;
 using RobotOM;
 using BH.oM.Structure.SectionProperties;
 using BH.oM.Geometry.ShapeProfiles;
@@ -49,7 +50,7 @@ namespace BH.Adapter.Robot
             sectionData.Type = IRobotBarSectionType.I_BST_NS_RECT;
             sectionData.ShapeType = IRobotBarSectionShapeType.I_BSST_CONCR_BEAM_RECT;
 
-            sectionData.MaterialName = material.Name;
+            sectionData.MaterialName = material.DescriptionOrName();
 
             IRobotBarSectionNonstdData nonStdData = sectionData.CreateNonstd(0);
             sectionData.Concrete.SetValue(IRobotBarSectionConcreteDataValue.I_BSCDV_BEAM_H, section.Height);
@@ -65,7 +66,7 @@ namespace BH.Adapter.Robot
             sectionData.Type = IRobotBarSectionType.I_BST_NS_T;
             sectionData.ShapeType = IRobotBarSectionShapeType.I_BSST_CONCR_BEAM_T;
 
-            sectionData.MaterialName = material.Name;
+            sectionData.MaterialName = material.DescriptionOrName();
 
             sectionData.Concrete.SetValue(IRobotBarSectionConcreteDataValue.I_BSCDV_BEAM_T_BF, section.Width);
             sectionData.Concrete.SetValue(IRobotBarSectionConcreteDataValue.I_BSCDV_BEAM_T_H, section.Height);
@@ -81,7 +82,7 @@ namespace BH.Adapter.Robot
         {
             sectionData.Type = IRobotBarSectionType.I_BST_NS_I;
             sectionData.ShapeType = IRobotBarSectionShapeType.I_BSST_CONCR_BEAM_I;
-            sectionData.MaterialName = material.Name;
+            sectionData.MaterialName = material.DescriptionOrName();
 
             sectionData.Concrete.SetValue(IRobotBarSectionConcreteDataValue.I_BSCDV_BEAM_I_B1, section.TopFlangeWidth);
             sectionData.Concrete.SetValue(IRobotBarSectionConcreteDataValue.I_BSCDV_BEAM_I_B2, section.BotFlangeWidth);
@@ -100,7 +101,7 @@ namespace BH.Adapter.Robot
             sectionData.Type = IRobotBarSectionType.I_BST_NS_C;
             sectionData.ShapeType = IRobotBarSectionShapeType.I_BSST_CONCR_COL_C;
 
-            sectionData.MaterialName = material.Name;
+            sectionData.MaterialName = material.DescriptionOrName();
 
             IRobotBarSectionNonstdData nonStdData = sectionData.CreateNonstd(0);
             sectionData.Concrete.SetValue(IRobotBarSectionConcreteDataValue.I_BSCDV_COL_DE, section.Diameter);
@@ -114,7 +115,7 @@ namespace BH.Adapter.Robot
         {
             sectionData.Type = IRobotBarSectionType.I_BST_NS_I;
             sectionData.ShapeType = IRobotBarSectionShapeType.I_BSST_CONCR_BEAM_I;
-            sectionData.MaterialName = material.Name;
+            sectionData.MaterialName = material.DescriptionOrName();
 
             sectionData.Concrete.SetValue(IRobotBarSectionConcreteDataValue.I_BSCDV_BEAM_I_B1, section.Width);
             sectionData.Concrete.SetValue(IRobotBarSectionConcreteDataValue.I_BSCDV_BEAM_I_B2, section.Width);
@@ -132,7 +133,7 @@ namespace BH.Adapter.Robot
         {
             BH.Engine.Reflection.Compute.RecordWarning("Profile of type " + section.GetType().Name + "is not yet fully supported for Concrete sections. Section with name " + sectionData.Name + " set as explicit section");
 
-            sectionData.MaterialName = material.Name;
+            sectionData.MaterialName = material.DescriptionOrName();
             ConcreteSection steelSection = BH.Engine.Structure.Create.ConcreteSectionFromProfile(section, material as Concrete);
 
             sectionData.SetValue(IRobotBarSectionDataValue.I_BSDV_AX, steelSection.Area);

--- a/Robot_Adapter/Convert/ToRobot/Properties/SectionProperty_Steel.cs
+++ b/Robot_Adapter/Convert/ToRobot/Properties/SectionProperty_Steel.cs
@@ -21,6 +21,7 @@
  */
 
 using BH.oM.Structure.MaterialFragments;
+using BH.Engine.Structure;
 using RobotOM;
 using BH.oM.Structure.SectionProperties;
 using BH.oM.Geometry.ShapeProfiles;
@@ -49,7 +50,7 @@ namespace BH.Adapter.Robot
             sectionData.Type = IRobotBarSectionType.I_BST_NS_RECT;
             sectionData.ShapeType = IRobotBarSectionShapeType.I_BSST_USER_RECT;
 
-            sectionData.MaterialName = material.Name;
+            sectionData.MaterialName = material.DescriptionOrName();
 
             IRobotBarSectionNonstdData nonStdData = sectionData.CreateNonstd(0);
 
@@ -66,7 +67,7 @@ namespace BH.Adapter.Robot
         {
             sectionData.Type = IRobotBarSectionType.I_BST_NS_BOX_3;
             sectionData.ShapeType = IRobotBarSectionShapeType.I_BSST_USER_BOX_3;
-            sectionData.MaterialName = material.Name;
+            sectionData.MaterialName = material.DescriptionOrName();
 
             IRobotBarSectionNonstdData nonStdData = sectionData.CreateNonstd(0);
 
@@ -88,7 +89,7 @@ namespace BH.Adapter.Robot
         {
             sectionData.Type = IRobotBarSectionType.I_BST_NS_II;
             sectionData.ShapeType = IRobotBarSectionShapeType.I_BSST_USER_I_MONOSYM;
-            sectionData.MaterialName = material.Name;
+            sectionData.MaterialName = material.DescriptionOrName();
 
             RobotBarSectionNonstdData nonStdData = sectionData.CreateNonstd(0);
 
@@ -108,7 +109,7 @@ namespace BH.Adapter.Robot
         {
             sectionData.Type = IRobotBarSectionType.I_BST_NS_I;
             sectionData.ShapeType = IRobotBarSectionShapeType.I_BSST_USER_I_BISYM;
-            sectionData.MaterialName = material.Name;
+            sectionData.MaterialName = material.DescriptionOrName();
 
             RobotBarSectionNonstdData nonStdData = sectionData.CreateNonstd(0);
 
@@ -127,7 +128,7 @@ namespace BH.Adapter.Robot
             sectionData.Type = IRobotBarSectionType.I_BST_NS_T;
             sectionData.ShapeType = IRobotBarSectionShapeType.I_BSST_USER_T_SHAPE;
 
-            sectionData.MaterialName = material.Name;
+            sectionData.MaterialName = material.DescriptionOrName();
 
             IRobotBarSectionNonstdData nonStdData = sectionData.CreateNonstd(0);
 
@@ -146,7 +147,7 @@ namespace BH.Adapter.Robot
             sectionData.Type = IRobotBarSectionType.I_BST_NS_TUBE;
             sectionData.ShapeType = IRobotBarSectionShapeType.I_BSST_USER_TUBE;
 
-            sectionData.MaterialName = material.Name;
+            sectionData.MaterialName = material.DescriptionOrName();
 
             IRobotBarSectionNonstdData nonStdData = sectionData.CreateNonstd(0);
 
@@ -163,7 +164,7 @@ namespace BH.Adapter.Robot
             sectionData.Type = IRobotBarSectionType.I_BST_NS_RECT;
             sectionData.ShapeType = IRobotBarSectionShapeType.I_BSST_RECT_FILLED;
 
-            sectionData.MaterialName = material.Name;
+            sectionData.MaterialName = material.DescriptionOrName();
 
             IRobotBarSectionNonstdData nonStdData = sectionData.CreateNonstd(0);
 
@@ -180,7 +181,7 @@ namespace BH.Adapter.Robot
             sectionData.Type = IRobotBarSectionType.I_BST_NS_TUBE;
             sectionData.ShapeType = IRobotBarSectionShapeType.I_BSST_CIRC_FILLED;
 
-            sectionData.MaterialName = material.Name;
+            sectionData.MaterialName = material.DescriptionOrName();
 
             IRobotBarSectionNonstdData nonStdData = sectionData.CreateNonstd(0);
 
@@ -195,7 +196,7 @@ namespace BH.Adapter.Robot
             sectionData.Type = IRobotBarSectionType.I_BST_NS_L;
             sectionData.ShapeType = IRobotBarSectionShapeType.I_BSST_UUAP;
 
-            sectionData.MaterialName = material.Name;
+            sectionData.MaterialName = material.DescriptionOrName();
 
             IRobotBarSectionNonstdData nonStdData = sectionData.CreateNonstd(0);
 
@@ -214,7 +215,7 @@ namespace BH.Adapter.Robot
             sectionData.Type = IRobotBarSectionType.I_BST_NS_C;
             sectionData.ShapeType = IRobotBarSectionShapeType.I_BSST_USER_C_SHAPE;
 
-            sectionData.MaterialName = material.Name;
+            sectionData.MaterialName = material.DescriptionOrName();
 
             IRobotBarSectionNonstdData nonStdData = sectionData.CreateNonstd(0);
 
@@ -233,7 +234,7 @@ namespace BH.Adapter.Robot
             sectionData.Type = IRobotBarSectionType.I_BST_NS_BOX_3;
             sectionData.ShapeType = IRobotBarSectionShapeType.I_BSST_USER_BOX_3;
 
-            sectionData.MaterialName = material.Name;
+            sectionData.MaterialName = material.DescriptionOrName();
 
             IRobotBarSectionNonstdData nonStdData = sectionData.CreateNonstd(0);
 
@@ -256,7 +257,7 @@ namespace BH.Adapter.Robot
         {
             BH.Engine.Reflection.Compute.RecordWarning("Profile of type " + section.GetType().Name + "is not yet fully supported for Steel sections. Section with name " + sectionData.Name + " set as explicit section");
 
-            sectionData.MaterialName = material.Name;
+            sectionData.MaterialName = material.DescriptionOrName();
             SteelSection steelSection = BH.Engine.Structure.Create.SteelSectionFromProfile(section, material as Steel);
 
             sectionData.SetValue(IRobotBarSectionDataValue.I_BSDV_AX, steelSection.Area);

--- a/Robot_Adapter/Types/Comparer.cs
+++ b/Robot_Adapter/Types/Comparer.cs
@@ -46,14 +46,14 @@ namespace BH.Adapter.Robot
             {
                 {typeof(Node), new NodeDistanceComparer(3) },
                 {typeof(Bar), new BarEndNodesDistanceComparer(3) },
-                {typeof(ISectionProperty), new BHoMObjectNameOrToStringComparer() },
-                {typeof(IMaterialFragment), new BHoMObjectNameComparer() },
-                {typeof(Constraint4DOF), new BHoMObjectNameComparer() },
-                {typeof(Constraint6DOF), new BHoMObjectNameComparer() },
-                {typeof(Loadcase), new BHoMObjectNameComparer() },
-                {typeof(LinkConstraint), new BHoMObjectNameComparer() },
-                {typeof(ISurfaceProperty), new BHoMObjectNameComparer() },
-                {typeof(BarRelease), new BHoMObjectNameComparer() }
+                {typeof(ISectionProperty), new NameOrDescriptionComparer() },
+                {typeof(IMaterialFragment), new NameOrDescriptionComparer() },
+                {typeof(Constraint4DOF), new NameOrDescriptionComparer() },
+                {typeof(Constraint6DOF), new NameOrDescriptionComparer() },
+                {typeof(Loadcase), new NameOrDescriptionComparer() },
+                {typeof(LinkConstraint), new NameOrDescriptionComparer() },
+                {typeof(ISurfaceProperty), new NameOrDescriptionComparer() },
+                {typeof(BarRelease), new NameOrDescriptionComparer() }
             };
         }
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

https://github.com/BHoM/BHoM_Engine/pull/1650

 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #263 

 <!-- Add short description of what has been fixed -->

Making use of new comparer that checks name or description of Property type objects

Making sure all labels with the new comparer are created using the DescriptionOrName method.

 ### Test files
<!-- Link to test files to validate the proposed changes -->

https://burohappold.sharepoint.com/:f:/s/BHoM/EuwqVlH1KiRJm3ixHE5sEUIB-H--uRzgA3S28U4qEcquqg?e=0d8jBo

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->

- Makes it so that you can push Property type objects with out first giving them a name
- If no name is provided, an Autogenerated description will be used in its place.

 ### Additional comments
<!-- As required -->
