### PR TITLE
Support for all geometrical sections and return ExplicitSection for profiles not yet supported

### DIFF
--- a/Robot_Adapter/CRUD/Create/Properties/Materials.cs
+++ b/Robot_Adapter/CRUD/Create/Properties/Materials.cs
@@ -44,14 +44,20 @@ namespace BH.Adapter.Robot
             foreach (IMaterialFragment material in materials)
             {
                 string match = Convert.Match(m_dbMaterialNames, material);
+                bool loadedFromDb = false;
                 if (match != null)
                 {
                     matData.LoadFromDBase(match);
-                    if (robotLabelServer.Exist(IRobotLabelType.I_LT_MATERIAL, match) == -1)
-                        MaterialExistsWarning(match);
-                    m_RobotApplication.Project.Structure.Labels.StoreWithName(label, match);
+                    if (matData.Type == Convert.GetMaterialType(material)) //Check that the material type matches, if not, create a new one instead of loading from DB
+                    {
+                        if (robotLabelServer.Exist(IRobotLabelType.I_LT_MATERIAL, match) == -1)
+                            MaterialExistsWarning(match);
+                        m_RobotApplication.Project.Structure.Labels.StoreWithName(label, match);
+                        loadedFromDb = true;
+                    }
                 }
-                else
+
+                if(!loadedFromDb)
                 {
                     string name = material.DescriptionOrName();
                     if (robotLabelServer.Exist(IRobotLabelType.I_LT_MATERIAL, name) == -1)

--- a/Robot_Adapter/CRUD/Create/Properties/SectionProperties.cs
+++ b/Robot_Adapter/CRUD/Create/Properties/SectionProperties.cs
@@ -57,7 +57,7 @@ namespace BH.Adapter.Robot
                 {
                     label = m_RobotApplication.Project.Structure.Labels.Create(IRobotLabelType.I_LT_BAR_SECTION, p.DescriptionOrName());
                     secData = label.Data;
-                    Convert.ToRobot(p, secData);
+                    Convert.IToRobot(p, secData);
                     m_RobotApplication.Project.Structure.Labels.Store(label);
                 }
             }

--- a/Robot_Adapter/CRUD/Read/Properties/Labels.cs
+++ b/Robot_Adapter/CRUD/Read/Properties/Labels.cs
@@ -68,7 +68,7 @@ namespace BH.Adapter.Robot
                             {
                                 sectionMaterial = ReadMaterialByLabelName(secData.MaterialName);
                             }
-                            ISectionProperty section = secData.FromRobot(sectionMaterial);
+                            ISectionProperty section = robotLabel.FromRobot(secData, sectionMaterial);
                             obj = section;
                             break;
                         case IRobotLabelType.I_LT_BAR_RELEASE:

--- a/Robot_Adapter/CRUD/Read/Properties/Labels.cs
+++ b/Robot_Adapter/CRUD/Read/Properties/Labels.cs
@@ -36,7 +36,7 @@ namespace BH.Adapter.Robot
         /****           Public Methods                  ****/
         /***************************************************/
 
-        public List<IBHoMObject> ReadLabels(IRobotLabelType robotLabelType)
+        public List<IBHoMObject> ReadLabels(IRobotLabelType robotLabelType, object dependantObjects = null)
         {
             IRobotLabelServer robotLabelServer = m_RobotApplication.Project.Structure.Labels;
             IRobotNamesArray robotLabelNames = robotLabelServer.GetAvailableNames(robotLabelType);            
@@ -59,6 +59,15 @@ namespace BH.Adapter.Robot
                         case IRobotLabelType.I_LT_NODE_COMPATIBILITY:
                             break;
                         case IRobotLabelType.I_LT_BAR_SECTION:
+                            Dictionary<string, IMaterialFragment> materials = dependantObjects as Dictionary<string, IMaterialFragment>;
+                            IRobotBarSectionData secData = robotLabel.Data as IRobotBarSectionData;
+                            IMaterialFragment sectionMaterial = null;
+                            if (materials != null && !materials.TryGetValue(secData.MaterialName, out sectionMaterial))
+                            {
+                                sectionMaterial = ReadMaterialByLabelName(secData.MaterialName);
+                            }
+                            ISectionProperty section = secData.FromRobot(sectionMaterial);
+                            obj = section;
                             break;
                         case IRobotLabelType.I_LT_BAR_RELEASE:
                             BarRelease barRelease = robotLabel.FromRobot(robotLabel.Data as IRobotBarReleaseData, robotLabelName);  
@@ -119,7 +128,7 @@ namespace BH.Adapter.Robot
                     }
                     if (obj != null)
                     {
-                        obj.CustomData.Add(AdapterIdName, robotLabelName);
+                        obj.CustomData[AdapterIdName] = robotLabelName;
                         obj.Name = robotLabelName;
                         objects.Add(obj);
                     }

--- a/Robot_Adapter/CRUD/Read/Properties/Labels.cs
+++ b/Robot_Adapter/CRUD/Read/Properties/Labels.cs
@@ -36,6 +36,8 @@ namespace BH.Adapter.Robot
         /****           Public Methods                  ****/
         /***************************************************/
 
+        //dependantObjects to be used for labels that require additional inner obejcts, such as Materials for SectionProeprties and SurfaceProeprties
+        //The method will assume this to be of a specific type
         public List<IBHoMObject> ReadLabels(IRobotLabelType robotLabelType, object dependantObjects = null)
         {
             IRobotLabelServer robotLabelServer = m_RobotApplication.Project.Structure.Labels;
@@ -59,10 +61,10 @@ namespace BH.Adapter.Robot
                         case IRobotLabelType.I_LT_NODE_COMPATIBILITY:
                             break;
                         case IRobotLabelType.I_LT_BAR_SECTION:
-                            Dictionary<string, IMaterialFragment> materials = dependantObjects as Dictionary<string, IMaterialFragment>;
+                            Dictionary<string, IMaterialFragment> bhomMaterials = dependantObjects as Dictionary<string, IMaterialFragment>;
                             IRobotBarSectionData secData = robotLabel.Data as IRobotBarSectionData;
                             IMaterialFragment sectionMaterial = null;
-                            if (materials != null && !materials.TryGetValue(secData.MaterialName, out sectionMaterial))
+                            if (bhomMaterials != null && !bhomMaterials.TryGetValue(secData.MaterialName, out sectionMaterial))
                             {
                                 sectionMaterial = ReadMaterialByLabelName(secData.MaterialName);
                             }
@@ -82,6 +84,10 @@ namespace BH.Adapter.Robot
                         case IRobotLabelType.I_LT_EDGE_SUPPORT:
                             break;
                         case IRobotLabelType.I_LT_PANEL_THICKNESS:
+                            bhomMaterials = dependantObjects as Dictionary<string, IMaterialFragment>;
+                            bhomMaterials = bhomMaterials ?? new Dictionary<string, IMaterialFragment>();
+                            ISurfaceProperty prop = Convert.FromRobot(robotLabel, bhomMaterials);
+                            obj = prop;
                             break;
                         case IRobotLabelType.I_LT_PANEL_REINFORCEMENT:
                             break;
@@ -114,8 +120,10 @@ namespace BH.Adapter.Robot
                         case IRobotLabelType.I_LT_BAR_NONLINEAR_HINGE:
                             break;
                         case IRobotLabelType.I_LT_CLADDING:
-                            //ISurfaceProperty cladding = Convert.FromRobot(robotLabel, robotLabelName);
-                            //obj = cladding;
+                            bhomMaterials = dependantObjects as Dictionary<string, IMaterialFragment>;
+                            bhomMaterials = bhomMaterials ?? new Dictionary<string, IMaterialFragment>();
+                            ISurfaceProperty cladding = Convert.FromRobot(robotLabel, bhomMaterials);
+                            obj = cladding;
                             break;
                         case IRobotLabelType.I_LT_PANEL_CALC_MODEL:
                             break;

--- a/Robot_Adapter/CRUD/Read/Properties/Labels.cs
+++ b/Robot_Adapter/CRUD/Read/Properties/Labels.cs
@@ -68,7 +68,7 @@ namespace BH.Adapter.Robot
                             {
                                 sectionMaterial = ReadMaterialByLabelName(secData.MaterialName);
                             }
-                            ISectionProperty section = robotLabel.FromRobot(secData, sectionMaterial);
+                            ISectionProperty section = secData.FromRobot(sectionMaterial, robotLabelName);
                             obj = section;
                             break;
                         case IRobotLabelType.I_LT_BAR_RELEASE:

--- a/Robot_Adapter/CRUD/Read/Properties/SurfaceProperties.cs
+++ b/Robot_Adapter/CRUD/Read/Properties/SurfaceProperties.cs
@@ -36,29 +36,11 @@ namespace BH.Adapter.Robot
 
         private List<ISurfaceProperty> ReadSurfaceProperties(List<string> names = null)
         {
-            List<ISurfaceProperty> BHoMProps = new List<ISurfaceProperty>();
-            IRobotLabelServer labelServer = m_RobotApplication.Project.Structure.Labels;
-            IRobotCollection rThicknessProps = labelServer.GetMany(IRobotLabelType.I_LT_PANEL_THICKNESS);
-            IRobotCollection rCladdingProps = labelServer.GetMany(IRobotLabelType.I_LT_CLADDING);
-            Dictionary<string, IMaterialFragment> BHoMMat = new Dictionary<string, IMaterialFragment>();
-            BHoMMat = (ReadMaterials().ToDictionary(x => x.Name));
+            Dictionary<string, IMaterialFragment> bhomMaterials = ReadMaterials().ToDictionary(x => x.Name);
 
-            for (int i = 1; i <= rThicknessProps.Count; i++)
-            {
-                IRobotLabel rThicknessProp = rThicknessProps.Get(i);
-                ISurfaceProperty tempProp = Convert.FromRobot(rThicknessProp, BHoMMat);
-                tempProp.CustomData.Add(AdapterIdName, tempProp.Name);
-                BHoMProps.Add(tempProp);
-            }
-
-            for (int i = 1; i <= rCladdingProps.Count; i++)
-            {
-                IRobotLabel rCladdingProp = rCladdingProps.Get(i);
-                ISurfaceProperty tempProp = Convert.FromRobot(rCladdingProp, BHoMMat);
-                tempProp.CustomData.Add(AdapterIdName, tempProp.Name);
-                BHoMProps.Add(tempProp);
-            }
-            return BHoMProps;
+            List<ISurfaceProperty> bhomProps = ReadLabels(IRobotLabelType.I_LT_PANEL_THICKNESS, bhomMaterials).Cast<ISurfaceProperty>().ToList();
+            bhomProps.AddRange(ReadLabels(IRobotLabelType.I_LT_CLADDING, bhomMaterials).Cast<ISurfaceProperty>());
+            return bhomProps;
         }
 
         /***************************************************/

--- a/Robot_Adapter/Convert/FromRobot/Properties/SectionProfile_Concrete.cs
+++ b/Robot_Adapter/Convert/FromRobot/Properties/SectionProfile_Concrete.cs
@@ -33,7 +33,7 @@ namespace BH.Adapter.Robot
         /****           Public Methods                  ****/
         /***************************************************/
         
-        public static ISectionProperty FromRobotConcreteSection(IRobotBarSectionData secData)
+        public static IProfile FromRobotConcreteProfile(IRobotBarSectionData secData)
         {
             double b = 0;
             double h = 0;
@@ -114,10 +114,7 @@ namespace BH.Adapter.Robot
                     return null;
             }
 
-            if (sectionProfile != null)
-                return BH.Engine.Structure.Create.ConcreteSectionFromProfile(sectionProfile);
-            else
-                return null;
+            return sectionProfile;
 
         }
 

--- a/Robot_Adapter/Convert/FromRobot/Properties/SectionProfile_General.cs
+++ b/Robot_Adapter/Convert/FromRobot/Properties/SectionProfile_General.cs
@@ -126,10 +126,21 @@ namespace BH.Adapter.Robot
                         sectionProfile = BH.Engine.Geometry.Create.TubeProfile(D, T);
                         break;
 
-                    case IRobotBarSectionShapeType.I_BSST_USER_RECT:
+                    case IRobotBarSectionShapeType.I_BSST_RECT_FILLED:
                         B = nonStdData.GetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_RECT_B);
                         H = nonStdData.GetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_RECT_H);
                         sectionProfile = BH.Engine.Geometry.Create.RectangleProfile(H, B, 0);
+                        break;
+
+                    case IRobotBarSectionShapeType.I_BSST_USER_RECT:
+                        B = nonStdData.GetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_RECT_B);
+                        H = nonStdData.GetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_RECT_H);
+                        T = nonStdData.GetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_RECT_T);
+
+                        if(T == 0)
+                            sectionProfile = BH.Engine.Geometry.Create.RectangleProfile(H, B, 0);
+                        else
+                            sectionProfile = BH.Engine.Geometry.Create.BoxProfile(H, B, T, 0, 0);
                         break;
 
                     case IRobotBarSectionShapeType.I_BSST_USER_I_BISYM:
@@ -173,7 +184,15 @@ namespace BH.Adapter.Robot
                         if (botOutstand < 0 && Math.Abs(botOutstand) < Tolerance.MicroDistance)
                             botOutstand = 0;
 
-                        sectionProfile = BH.Engine.Geometry.Create.GeneralisedFabricatedBoxProfile(H + TF + TF2, B1 + (2 * TW), TW, TF, TF2, topOutstand, botOutstand);
+                        //If outstands are 0 (less than microdistance fraction of the width) return a standard fabricated box section.
+                        if (B1 > Tolerance.Distance && topOutstand / B1 < Tolerance.MicroDistance && botOutstand / B1 < Tolerance.MicroDistance)
+                        {
+                            sectionProfile = BH.Engine.Geometry.Create.FabricatedBoxProfile(H + TF + TF2, B1 + 2 * TW, TW, TF, TF2, 0);
+                        }
+                        else
+                        {
+                            sectionProfile = BH.Engine.Geometry.Create.GeneralisedFabricatedBoxProfile(H + TF + TF2, B1 + (2 * TW), TW, TF, TF2, topOutstand, botOutstand);
+                        }
                         break;
 
                     case IRobotBarSectionShapeType.I_BSST_BOX:

--- a/Robot_Adapter/Convert/FromRobot/Properties/SectionProfile_General.cs
+++ b/Robot_Adapter/Convert/FromRobot/Properties/SectionProfile_General.cs
@@ -35,7 +35,7 @@ namespace BH.Adapter.Robot
         /****           Public Methods                  ****/
         /***************************************************/
 
-        public static ISectionProperty FromRobotSteelSection(IRobotBarSectionData secData)
+        public static IProfile FromRobotGeneralProfile(IRobotBarSectionData secData)
         {
             IProfile sectionProfile = null;
 
@@ -204,10 +204,8 @@ namespace BH.Adapter.Robot
                 }
             }
 
-            if (sectionProfile != null)
-                return BH.Engine.Structure.Create.SteelSectionFromProfile(sectionProfile);
-            else
-                return null;
+            return sectionProfile;
+
         }
 
         /***************************************************/

--- a/Robot_Adapter/Convert/FromRobot/Properties/SectionProperty.cs
+++ b/Robot_Adapter/Convert/FromRobot/Properties/SectionProperty.cs
@@ -20,7 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using BH.oM.Physical.Materials;
+using BH.oM.Geometry.ShapeProfiles;
 using BH.oM.Structure.MaterialFragments;
 using RobotOM;
 using BH.oM.Structure.SectionProperties;
@@ -38,13 +38,16 @@ namespace BH.Adapter.Robot
         {
 
             ISectionProperty prop = null;
-
-            if (material is Steel)
-                prop = FromRobotSteelSection(secData);
-            else if (material is Concrete)
-                prop = FromRobotConcreteSection(secData);
+            IProfile profile = null;
             
-            if(prop == null)
+            if (secData.IsConcrete)
+                profile = FromRobotConcreteProfile(secData);
+            else
+                profile = FromRobotGeneralProfile(secData);
+
+            if (profile != null)
+                prop = Create.SectionPropertyFromProfile(profile, material, secData.Name);            
+            else
             {
 
                 string message = "Failed to convert the section named " + secData.Name + " to a geometric section.";

--- a/Robot_Adapter/Convert/FromRobot/Properties/SectionProperty.cs
+++ b/Robot_Adapter/Convert/FromRobot/Properties/SectionProperty.cs
@@ -34,7 +34,7 @@ namespace BH.Adapter.Robot
         /****           Public Methods                  ****/
         /***************************************************/
 
-        public static ISectionProperty FromRobot(this IRobotLabel robotLabel, IRobotBarSectionData secData, IMaterialFragment material)
+        public static ISectionProperty FromRobot(this IRobotBarSectionData secData, IMaterialFragment material, string robotLabelName)
         {
 
             ISectionProperty prop = null;
@@ -50,9 +50,9 @@ namespace BH.Adapter.Robot
             else
             {
 
-                string message = "Failed to convert the section named " + robotLabel.Name + " to a geometric section.";
+                string message = "Failed to convert the section named " + robotLabelName + " to a geometric section.";
 
-                ExplicitSection exp = new ExplicitSection() { Name = secData.Name, Material = material };
+                ExplicitSection exp = new ExplicitSection() { Name = robotLabelName, Material = material };
 
                 try
                 {

--- a/Robot_Adapter/Convert/FromRobot/Properties/SectionProperty.cs
+++ b/Robot_Adapter/Convert/FromRobot/Properties/SectionProperty.cs
@@ -34,7 +34,7 @@ namespace BH.Adapter.Robot
         /****           Public Methods                  ****/
         /***************************************************/
 
-        public static ISectionProperty FromRobot(IRobotBarSectionData secData, IMaterialFragment material)
+        public static ISectionProperty FromRobot(this IRobotBarSectionData secData, IMaterialFragment material)
         {
 
             ISectionProperty prop = null;
@@ -52,7 +52,7 @@ namespace BH.Adapter.Robot
 
                 string message = "Failed to convert the section named " + secData.Name + " to a geometric section.";
 
-                ExplicitSection exp = new ExplicitSection() { Name = secData.Name };
+                ExplicitSection exp = new ExplicitSection() { Name = secData.Name, Material = material };
 
                 try
                 {
@@ -64,6 +64,9 @@ namespace BH.Adapter.Robot
                     exp.Vz = secData.GetValue(IRobotBarSectionDataValue.I_BSDV_VZ);
                     exp.Vpy = secData.GetValue(IRobotBarSectionDataValue.I_BSDV_VPY);
                     exp.Vpz = secData.GetValue(IRobotBarSectionDataValue.I_BSDV_VPZ);
+                    exp.Wply = secData.GetValue(IRobotBarSectionDataValue.I_BSDV_ZY);
+                    exp.Wplz = secData.GetValue(IRobotBarSectionDataValue.I_BSDV_ZZ);
+
                     message += " Section has been returned as explicit with main analytical properties set.";
                 }
                 catch (System.Exception)
@@ -71,8 +74,8 @@ namespace BH.Adapter.Robot
                     message += " Section has been returned as an empty explicit section";
                 }
                 Engine.Reflection.Compute.RecordWarning(message);
-                prop = exp;
 
+                prop = exp;
             }
 
             return prop;           

--- a/Robot_Adapter/Convert/FromRobot/Properties/SectionProperty.cs
+++ b/Robot_Adapter/Convert/FromRobot/Properties/SectionProperty.cs
@@ -34,7 +34,7 @@ namespace BH.Adapter.Robot
         /****           Public Methods                  ****/
         /***************************************************/
 
-        public static ISectionProperty FromRobot(this IRobotBarSectionData secData, IMaterialFragment material)
+        public static ISectionProperty FromRobot(this IRobotLabel robotLabel, IRobotBarSectionData secData, IMaterialFragment material)
         {
 
             ISectionProperty prop = null;
@@ -50,7 +50,7 @@ namespace BH.Adapter.Robot
             else
             {
 
-                string message = "Failed to convert the section named " + secData.Name + " to a geometric section.";
+                string message = "Failed to convert the section named " + robotLabel.Name + " to a geometric section.";
 
                 ExplicitSection exp = new ExplicitSection() { Name = secData.Name, Material = material };
 

--- a/Robot_Adapter/Convert/FromRobot/Properties/SectionProperty.cs
+++ b/Robot_Adapter/Convert/FromRobot/Properties/SectionProperty.cs
@@ -36,15 +36,43 @@ namespace BH.Adapter.Robot
 
         public static ISectionProperty FromRobot(IRobotBarSectionData secData, IMaterialFragment material)
         {
+
+            ISectionProperty prop = null;
+
             if (material is Steel)
-                return FromRobotSteelSection(secData);
-            if (material is Concrete)
-                return FromRobotConcreteSection(secData);
-            else
+                prop = FromRobotSteelSection(secData);
+            else if (material is Concrete)
+                prop = FromRobotConcreteSection(secData);
+            
+            if(prop == null)
             {
-                Engine.Reflection.Compute.RecordWarning("Section proeprty of material type " + material.GetType().Name + " currently not supported. Section with label " + secData.Name + " was not extracted from the model");
-                return null;
-            }            
+
+                string message = "Failed to convert the section named " + secData.Name + " to a geometric section.";
+
+                ExplicitSection exp = new ExplicitSection() { Name = secData.Name };
+
+                try
+                {
+                    exp.Area = secData.GetValue(IRobotBarSectionDataValue.I_BSDV_AX);
+                    exp.J = secData.GetValue(IRobotBarSectionDataValue.I_BSDV_IX);
+                    exp.Iy = secData.GetValue(IRobotBarSectionDataValue.I_BSDV_IY);
+                    exp.Iz = secData.GetValue(IRobotBarSectionDataValue.I_BSDV_IZ);
+                    exp.Vy = secData.GetValue(IRobotBarSectionDataValue.I_BSDV_VY);
+                    exp.Vz = secData.GetValue(IRobotBarSectionDataValue.I_BSDV_VZ);
+                    exp.Vpy = secData.GetValue(IRobotBarSectionDataValue.I_BSDV_VPY);
+                    exp.Vpz = secData.GetValue(IRobotBarSectionDataValue.I_BSDV_VPZ);
+                    message += " Section has been returned as explicit with main analytical properties set.";
+                }
+                catch (System.Exception)
+                {
+                    message += " Section has been returned as an empty explicit section";
+                }
+                Engine.Reflection.Compute.RecordWarning(message);
+                prop = exp;
+
+            }
+
+            return prop;           
         }
 
         /***************************************************/

--- a/Robot_Adapter/Convert/ToRobot/Properties/SectionProperty.cs
+++ b/Robot_Adapter/Convert/ToRobot/Properties/SectionProperty.cs
@@ -34,17 +34,16 @@ namespace BH.Adapter.Robot
         /****           Public Methods                  ****/
         /***************************************************/
 
-        public static void ToRobot(this ISectionProperty section, IRobotBarSectionData secData)
+        public static void IToRobot(this ISectionProperty section, IRobotBarSectionData secData)
         {
-            ToRobot(section as dynamic, section.Material, secData);
+            secData.MaterialName = section.Material.DescriptionOrName(); //Set the material to the section
+            ToRobot(section as dynamic, secData);
         }
 
         /***************************************************/
 
-        public static void ToRobot(this ExplicitSection section, IMaterialFragment material, IRobotBarSectionData secData)
+        public static void ToRobot(this ExplicitSection section, IRobotBarSectionData secData)
         {
-            secData.MaterialName = material.DescriptionOrName();
-
             secData.SetValue(IRobotBarSectionDataValue.I_BSDV_AX, section.Area);
             secData.SetValue(IRobotBarSectionDataValue.I_BSDV_IX, section.J);
             secData.SetValue(IRobotBarSectionDataValue.I_BSDV_IY, section.Iy);
@@ -53,15 +52,16 @@ namespace BH.Adapter.Robot
             secData.SetValue(IRobotBarSectionDataValue.I_BSDV_VZ, section.Vz);
             secData.SetValue(IRobotBarSectionDataValue.I_BSDV_VPY, section.Vpy);
             secData.SetValue(IRobotBarSectionDataValue.I_BSDV_VPZ, section.Vpz);
+            secData.SetValue(IRobotBarSectionDataValue.I_BSDV_ZY, section.Wply);
+            secData.SetValue(IRobotBarSectionDataValue.I_BSDV_ZZ, section.Wplz);
 
             secData.CalcNonstdGeometry();
         }
 
         /***************************************************/
 
-        public static void ToRobot(this ISectionProperty section, IMaterialFragment material, IRobotBarSectionData secData)
+        public static void ToRobot(this ISectionProperty section, IRobotBarSectionData secData)
         {
-            secData.MaterialName = material.DescriptionOrName();
             Engine.Reflection.Compute.RecordWarning("Section of type " + section.GetType().Name + " is not yet supported in the Robot adapter. Section with name " + secData.Name + " will not have any properties set");
         }
         

--- a/Robot_Adapter/Convert/ToRobot/Properties/SectionProperty_Concrete.cs
+++ b/Robot_Adapter/Convert/ToRobot/Properties/SectionProperty_Concrete.cs
@@ -34,39 +34,48 @@ namespace BH.Adapter.Robot
         /****           Public Methods                  ****/
         /***************************************************/
 
-        public static void ToRobot(this ConcreteSection section, IMaterialFragment material, IRobotBarSectionData secData)
+        public static void ToRobot(this ConcreteSection section, IRobotBarSectionData secData)
         {
-            ToRobotConcreteSection(section.SectionProfile as dynamic, material, secData);
+            if (!ToRobotConcreteSection(section.SectionProfile as dynamic, secData))
+            {
+                //If method returns false, no profile based data has been set. Fallback to explicitly setting properties.
+                secData.SetValue(IRobotBarSectionDataValue.I_BSDV_AX, section.Area);
+                secData.SetValue(IRobotBarSectionDataValue.I_BSDV_IX, section.J);
+                secData.SetValue(IRobotBarSectionDataValue.I_BSDV_IY, section.Iy);
+                secData.SetValue(IRobotBarSectionDataValue.I_BSDV_IZ, section.Iz);
+                secData.SetValue(IRobotBarSectionDataValue.I_BSDV_VY, section.Vy);
+                secData.SetValue(IRobotBarSectionDataValue.I_BSDV_VZ, section.Vz);
+                secData.SetValue(IRobotBarSectionDataValue.I_BSDV_VPY, section.Vpy);
+                secData.SetValue(IRobotBarSectionDataValue.I_BSDV_VPZ, section.Vpz);
+                secData.SetValue(IRobotBarSectionDataValue.I_BSDV_ZY, section.Wply);
+                secData.SetValue(IRobotBarSectionDataValue.I_BSDV_ZZ, section.Wplz);
+                secData.CalcNonstdGeometry();
+            }
         }
-
-        /***************************************************/
 
         /***************************************************/
         /****           Private Methods                 ****/
         /***************************************************/
 
-        private static void ToRobotConcreteSection(this RectangleProfile section, IMaterialFragment material, IRobotBarSectionData sectionData)
+        private static bool ToRobotConcreteSection(this RectangleProfile section, IRobotBarSectionData sectionData)
         {
             sectionData.Type = IRobotBarSectionType.I_BST_NS_RECT;
             sectionData.ShapeType = IRobotBarSectionShapeType.I_BSST_CONCR_BEAM_RECT;
-
-            sectionData.MaterialName = material.DescriptionOrName();
 
             IRobotBarSectionNonstdData nonStdData = sectionData.CreateNonstd(0);
             sectionData.Concrete.SetValue(IRobotBarSectionConcreteDataValue.I_BSCDV_BEAM_H, section.Height);
             sectionData.Concrete.SetValue(IRobotBarSectionConcreteDataValue.I_BSCDV_BEAM_B, section.Width);
 
             sectionData.CalcNonstdGeometry();
+            return true;
         }
 
         /***************************************************/
 
-        private static void ToRobotConcreteSection(this TSectionProfile section, IMaterialFragment material, IRobotBarSectionData sectionData)
+        private static bool ToRobotConcreteSection(this TSectionProfile section, IRobotBarSectionData sectionData)
         {
             sectionData.Type = IRobotBarSectionType.I_BST_NS_T;
             sectionData.ShapeType = IRobotBarSectionShapeType.I_BSST_CONCR_BEAM_T;
-
-            sectionData.MaterialName = material.DescriptionOrName();
 
             sectionData.Concrete.SetValue(IRobotBarSectionConcreteDataValue.I_BSCDV_BEAM_T_BF, section.Width);
             sectionData.Concrete.SetValue(IRobotBarSectionConcreteDataValue.I_BSCDV_BEAM_T_H, section.Height);
@@ -74,15 +83,15 @@ namespace BH.Adapter.Robot
             sectionData.Concrete.SetValue(IRobotBarSectionConcreteDataValue.I_BSCDV_BEAM_T_B, section.WebThickness);
 
             sectionData.CalcNonstdGeometry();
+            return true;
         }
 
         /***************************************************/
 
-        private static void ToRobotConcreteSection(this FabricatedISectionProfile section, IMaterialFragment material, IRobotBarSectionData sectionData)
+        private static bool ToRobotConcreteSection(this FabricatedISectionProfile section, IRobotBarSectionData sectionData)
         {
             sectionData.Type = IRobotBarSectionType.I_BST_NS_I;
             sectionData.ShapeType = IRobotBarSectionShapeType.I_BSST_CONCR_BEAM_I;
-            sectionData.MaterialName = material.DescriptionOrName();
 
             sectionData.Concrete.SetValue(IRobotBarSectionConcreteDataValue.I_BSCDV_BEAM_I_B1, section.TopFlangeWidth);
             sectionData.Concrete.SetValue(IRobotBarSectionConcreteDataValue.I_BSCDV_BEAM_I_B2, section.BotFlangeWidth);
@@ -92,30 +101,29 @@ namespace BH.Adapter.Robot
             sectionData.Concrete.SetValue(IRobotBarSectionConcreteDataValue.I_BSCDV_BEAM_I_B, section.WebThickness);
 
             sectionData.CalcNonstdGeometry();
+            return true;
         }
 
         /***************************************************/
 
-        private static void ToRobotConcreteSection(this CircleProfile section, IMaterialFragment material, IRobotBarSectionData sectionData)
+        private static bool ToRobotConcreteSection(this CircleProfile section, IRobotBarSectionData sectionData)
         {
             sectionData.Type = IRobotBarSectionType.I_BST_NS_C;
             sectionData.ShapeType = IRobotBarSectionShapeType.I_BSST_CONCR_COL_C;
-
-            sectionData.MaterialName = material.DescriptionOrName();
 
             IRobotBarSectionNonstdData nonStdData = sectionData.CreateNonstd(0);
             sectionData.Concrete.SetValue(IRobotBarSectionConcreteDataValue.I_BSCDV_COL_DE, section.Diameter);
 
             sectionData.CalcNonstdGeometry();
+            return true;
         }
 
         /***************************************************/
 
-        private static void ToRobotConcreteSection(this ISectionProfile section, IMaterialFragment material, IRobotBarSectionData sectionData)
+        private static bool ToRobotConcreteSection(this ISectionProfile section, IRobotBarSectionData sectionData)
         {
             sectionData.Type = IRobotBarSectionType.I_BST_NS_I;
             sectionData.ShapeType = IRobotBarSectionShapeType.I_BSST_CONCR_BEAM_I;
-            sectionData.MaterialName = material.DescriptionOrName();
 
             sectionData.Concrete.SetValue(IRobotBarSectionConcreteDataValue.I_BSCDV_BEAM_I_B1, section.Width);
             sectionData.Concrete.SetValue(IRobotBarSectionConcreteDataValue.I_BSCDV_BEAM_I_B2, section.Width);
@@ -125,27 +133,15 @@ namespace BH.Adapter.Robot
             sectionData.Concrete.SetValue(IRobotBarSectionConcreteDataValue.I_BSCDV_BEAM_I_B, section.WebThickness);
 
             sectionData.CalcNonstdGeometry();
+            return true;
         }
 
         /***************************************************/
 
-        private static void ToRobotConcreteSection(this IProfile section, IMaterialFragment material, IRobotBarSectionData sectionData)
+        private static bool ToRobotConcreteSection(this IProfile section, IRobotBarSectionData sectionData)
         {
             BH.Engine.Reflection.Compute.RecordWarning("Profile of type " + section.GetType().Name + "is not yet fully supported for Concrete sections. Section with name " + sectionData.Name + " set as explicit section");
-
-            sectionData.MaterialName = material.DescriptionOrName();
-            ConcreteSection steelSection = BH.Engine.Structure.Create.ConcreteSectionFromProfile(section, material as Concrete);
-
-            sectionData.SetValue(IRobotBarSectionDataValue.I_BSDV_AX, steelSection.Area);
-            sectionData.SetValue(IRobotBarSectionDataValue.I_BSDV_IX, steelSection.J);
-            sectionData.SetValue(IRobotBarSectionDataValue.I_BSDV_IY, steelSection.Iy);
-            sectionData.SetValue(IRobotBarSectionDataValue.I_BSDV_IZ, steelSection.Iz);
-            sectionData.SetValue(IRobotBarSectionDataValue.I_BSDV_VY, steelSection.Vy);
-            sectionData.SetValue(IRobotBarSectionDataValue.I_BSDV_VZ, steelSection.Vz);
-            sectionData.SetValue(IRobotBarSectionDataValue.I_BSDV_VPY, steelSection.Vpy);
-            sectionData.SetValue(IRobotBarSectionDataValue.I_BSDV_VPZ, steelSection.Vpz);
-
-            sectionData.CalcNonstdGeometry();
+            return false;
         }
 
         /***************************************************/

--- a/Robot_Adapter/Convert/ToRobot/Properties/SectionProperty_Concrete.cs
+++ b/Robot_Adapter/Convert/ToRobot/Properties/SectionProperty_Concrete.cs
@@ -140,7 +140,7 @@ namespace BH.Adapter.Robot
 
         private static bool ToRobotConcreteSection(this IProfile section, IRobotBarSectionData sectionData)
         {
-            BH.Engine.Reflection.Compute.RecordWarning("Profile of type " + section.GetType().Name + "is not yet fully supported for Concrete sections. Section with name " + sectionData.Name + " set as explicit section");
+            BH.Engine.Reflection.Compute.RecordWarning("Profile of type " + section.GetType().Name + " is not yet fully supported for Concrete sections. Section with name " + sectionData.Name + " set as explicit section");
             return false;
         }
 

--- a/Robot_Adapter/Convert/ToRobot/Properties/SectionProperty_Geometrical.cs
+++ b/Robot_Adapter/Convert/ToRobot/Properties/SectionProperty_Geometrical.cs
@@ -34,23 +34,33 @@ namespace BH.Adapter.Robot
         /****           Public Methods                  ****/
         /***************************************************/
 
-        public static void ToRobot(this IGeometricalSection section, IMaterialFragment material, IRobotBarSectionData secData)
+        public static void ToRobot(this IGeometricalSection section, IRobotBarSectionData secData)
         {
-            ToRobotGeometricalSection(section.SectionProfile as dynamic, material, secData);
+            if (!ToRobotGeometricalSection(section.SectionProfile as dynamic, secData))
+            {
+                //If method returns false, no profile based data has been set. Fallback to explicitly setting properties.
+                secData.SetValue(IRobotBarSectionDataValue.I_BSDV_AX, section.Area);
+                secData.SetValue(IRobotBarSectionDataValue.I_BSDV_IX, section.J);
+                secData.SetValue(IRobotBarSectionDataValue.I_BSDV_IY, section.Iy);
+                secData.SetValue(IRobotBarSectionDataValue.I_BSDV_IZ, section.Iz);
+                secData.SetValue(IRobotBarSectionDataValue.I_BSDV_VY, section.Vy);
+                secData.SetValue(IRobotBarSectionDataValue.I_BSDV_VZ, section.Vz);
+                secData.SetValue(IRobotBarSectionDataValue.I_BSDV_VPY, section.Vpy);
+                secData.SetValue(IRobotBarSectionDataValue.I_BSDV_VPZ, section.Vpz);
+                secData.SetValue(IRobotBarSectionDataValue.I_BSDV_ZY, section.Wply);
+                secData.SetValue(IRobotBarSectionDataValue.I_BSDV_ZZ, section.Wplz);
+                secData.CalcNonstdGeometry();
+            }
         }
-
-        /***************************************************/
 
         /***************************************************/
         /****           Private Methods                  ****/
         /***************************************************/
 
-        private static void ToRobotGeometricalSection(this BoxProfile section, IMaterialFragment material, IRobotBarSectionData sectionData)
+        private static bool ToRobotGeometricalSection(this BoxProfile section, IRobotBarSectionData sectionData)
         {
             sectionData.Type = IRobotBarSectionType.I_BST_NS_RECT;
             sectionData.ShapeType = IRobotBarSectionShapeType.I_BSST_USER_RECT;
-
-            sectionData.MaterialName = material.DescriptionOrName();
 
             IRobotBarSectionNonstdData nonStdData = sectionData.CreateNonstd(0);
 
@@ -59,15 +69,15 @@ namespace BH.Adapter.Robot
             nonStdData.SetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_RECT_T, section.Thickness);
 
             sectionData.CalcNonstdGeometry();
+            return true;
         }
 
         /***************************************************/
 
-        private static void ToRobotGeometricalSection(this FabricatedBoxProfile section, IMaterialFragment material, IRobotBarSectionData sectionData)
+        private static bool ToRobotGeometricalSection(this FabricatedBoxProfile section, IRobotBarSectionData sectionData)
         {
             sectionData.Type = IRobotBarSectionType.I_BST_NS_BOX_3;
             sectionData.ShapeType = IRobotBarSectionShapeType.I_BSST_USER_BOX_3;
-            sectionData.MaterialName = material.DescriptionOrName();
 
             IRobotBarSectionNonstdData nonStdData = sectionData.CreateNonstd(0);
 
@@ -81,15 +91,15 @@ namespace BH.Adapter.Robot
             nonStdData.SetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_BOX_3_TF2, section.BotFlangeThickness);
 
             sectionData.CalcNonstdGeometry();
+            return true;
         }
 
         /***************************************************/
 
-        private static void ToRobotGeometricalSection(this FabricatedISectionProfile section, IMaterialFragment material, IRobotBarSectionData sectionData)
+        private static bool ToRobotGeometricalSection(this FabricatedISectionProfile section, IRobotBarSectionData sectionData)
         {
             sectionData.Type = IRobotBarSectionType.I_BST_NS_II;
             sectionData.ShapeType = IRobotBarSectionShapeType.I_BSST_USER_I_MONOSYM;
-            sectionData.MaterialName = material.DescriptionOrName();
 
             RobotBarSectionNonstdData nonStdData = sectionData.CreateNonstd(0);
 
@@ -101,15 +111,15 @@ namespace BH.Adapter.Robot
             nonStdData.SetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_II_TF2, section.BotFlangeThickness);
 
             sectionData.CalcNonstdGeometry();
+            return true;
         }
 
         /***************************************************/
 
-        private static void ToRobotGeometricalSection(this ISectionProfile section, IMaterialFragment material, IRobotBarSectionData sectionData)
+        private static bool ToRobotGeometricalSection(this ISectionProfile section, IRobotBarSectionData sectionData)
         {
             sectionData.Type = IRobotBarSectionType.I_BST_NS_I;
             sectionData.ShapeType = IRobotBarSectionShapeType.I_BSST_USER_I_BISYM;
-            sectionData.MaterialName = material.DescriptionOrName();
 
             RobotBarSectionNonstdData nonStdData = sectionData.CreateNonstd(0);
 
@@ -119,16 +129,15 @@ namespace BH.Adapter.Robot
             nonStdData.SetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_I_TF, section.FlangeThickness);
 
             sectionData.CalcNonstdGeometry();
+            return true;
         }
 
         /***************************************************/
 
-        private static void ToRobotGeometricalSection(this TSectionProfile section, IMaterialFragment material, IRobotBarSectionData sectionData)
+        private static bool ToRobotGeometricalSection(this TSectionProfile section, IRobotBarSectionData sectionData)
         {
             sectionData.Type = IRobotBarSectionType.I_BST_NS_T;
             sectionData.ShapeType = IRobotBarSectionShapeType.I_BSST_USER_T_SHAPE;
-
-            sectionData.MaterialName = material.DescriptionOrName();
 
             IRobotBarSectionNonstdData nonStdData = sectionData.CreateNonstd(0);
 
@@ -138,16 +147,15 @@ namespace BH.Adapter.Robot
             nonStdData.SetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_T_TW, section.WebThickness);
 
             sectionData.CalcNonstdGeometry();
+            return true;
         }
 
         /***************************************************/
 
-        private static void ToRobotGeometricalSection(this TubeProfile section, IMaterialFragment material, IRobotBarSectionData sectionData)
+        private static bool ToRobotGeometricalSection(this TubeProfile section, IRobotBarSectionData sectionData)
         {
             sectionData.Type = IRobotBarSectionType.I_BST_NS_TUBE;
             sectionData.ShapeType = IRobotBarSectionShapeType.I_BSST_USER_TUBE;
-
-            sectionData.MaterialName = material.DescriptionOrName();
 
             IRobotBarSectionNonstdData nonStdData = sectionData.CreateNonstd(0);
 
@@ -155,16 +163,15 @@ namespace BH.Adapter.Robot
             nonStdData.SetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_TUBE_T, section.Thickness);
 
             sectionData.CalcNonstdGeometry();
+            return true;
         }
 
         /***************************************************/
 
-        private static void ToRobotGeometricalSection(this RectangleProfile section, IMaterialFragment material, IRobotBarSectionData sectionData)
+        private static bool ToRobotGeometricalSection(this RectangleProfile section, IRobotBarSectionData sectionData)
         {
             sectionData.Type = IRobotBarSectionType.I_BST_NS_RECT;
             sectionData.ShapeType = IRobotBarSectionShapeType.I_BSST_RECT_FILLED;
-
-            sectionData.MaterialName = material.DescriptionOrName();
 
             IRobotBarSectionNonstdData nonStdData = sectionData.CreateNonstd(0);
 
@@ -172,26 +179,26 @@ namespace BH.Adapter.Robot
             nonStdData.SetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_RECT_B, section.Width);
 
             sectionData.CalcNonstdGeometry();
+            return true;
         }
 
         /***************************************************/
 
-        private static void ToRobotGeometricalSection(this CircleProfile section, IMaterialFragment material, IRobotBarSectionData sectionData)
+        private static bool ToRobotGeometricalSection(this CircleProfile section, IRobotBarSectionData sectionData)
         {
             sectionData.Type = IRobotBarSectionType.I_BST_NS_TUBE;
             sectionData.ShapeType = IRobotBarSectionShapeType.I_BSST_CIRC_FILLED;
-
-            sectionData.MaterialName = material.DescriptionOrName();
 
             IRobotBarSectionNonstdData nonStdData = sectionData.CreateNonstd(0);
 
             nonStdData.SetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_TUBE_D, section.Diameter);
             sectionData.CalcNonstdGeometry();
+            return true;
         }
 
         /***************************************************/
 
-        //private static void ToRobotGeometricalSection(this AngleProfile section, IMaterialFragment material, IRobotBarSectionData sectionData)
+        //private static bool ToRobotGeometricalSection(this AngleProfile section, IMaterialFragment material, IRobotBarSectionData sectionData)
         //{
         //    sectionData.Type = IRobotBarSectionType.I_BST_NS_L;
         //    sectionData.ShapeType = IRobotBarSectionShapeType.I_BSST_UUAP;
@@ -210,12 +217,10 @@ namespace BH.Adapter.Robot
 
         /***************************************************/
 
-        private static void ToRobotGeometricalSection(this ChannelProfile section, IMaterialFragment material, IRobotBarSectionData sectionData)
+        private static bool ToRobotGeometricalSection(this ChannelProfile section, IRobotBarSectionData sectionData)
         {
             sectionData.Type = IRobotBarSectionType.I_BST_NS_C;
             sectionData.ShapeType = IRobotBarSectionShapeType.I_BSST_USER_C_SHAPE;
-
-            sectionData.MaterialName = material.DescriptionOrName();
 
             IRobotBarSectionNonstdData nonStdData = sectionData.CreateNonstd(0);
 
@@ -225,16 +230,15 @@ namespace BH.Adapter.Robot
             nonStdData.SetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_C_TF, section.FlangeThickness);
 
             sectionData.CalcNonstdGeometry();
+            return true;
         }
 
         /***************************************************/
 
-        private static void ToRobotGeometricalSection(this GeneralisedFabricatedBoxProfile section, IMaterialFragment material, IRobotBarSectionData sectionData)
+        private static bool ToRobotGeometricalSection(this GeneralisedFabricatedBoxProfile section, IRobotBarSectionData sectionData)
         {
             sectionData.Type = IRobotBarSectionType.I_BST_NS_BOX_3;
             sectionData.ShapeType = IRobotBarSectionShapeType.I_BSST_USER_BOX_3;
-
-            sectionData.MaterialName = material.DescriptionOrName();
 
             IRobotBarSectionNonstdData nonStdData = sectionData.CreateNonstd(0);
 
@@ -248,30 +252,18 @@ namespace BH.Adapter.Robot
             nonStdData.SetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_BOX_3_TF2, section.BotFlangeThickness);
 
             sectionData.CalcNonstdGeometry();
+            return true;
 
         }
 
         /***************************************************/
 
-        private static void ToRobotGeometricalSection(this IProfile section, IMaterialFragment material, IRobotBarSectionData sectionData)
+        private static bool ToRobotGeometricalSection(this IProfile section, IRobotBarSectionData sectionData)
         {
             BH.Engine.Reflection.Compute.RecordWarning("Profile of type " + section.GetType().Name + "is not yet fully supported for Steel sections. Section with name " + sectionData.Name + " set as explicit section");
-
-            sectionData.MaterialName = material.DescriptionOrName();
-            IGeometricalSection steelSection = Create.SectionPropertyFromProfile(section, material as Steel);
-
-            sectionData.SetValue(IRobotBarSectionDataValue.I_BSDV_AX, steelSection.Area);
-            sectionData.SetValue(IRobotBarSectionDataValue.I_BSDV_IX, steelSection.J);
-            sectionData.SetValue(IRobotBarSectionDataValue.I_BSDV_IY, steelSection.Iy);
-            sectionData.SetValue(IRobotBarSectionDataValue.I_BSDV_IZ, steelSection.Iz);
-            sectionData.SetValue(IRobotBarSectionDataValue.I_BSDV_VY, steelSection.Vy);
-            sectionData.SetValue(IRobotBarSectionDataValue.I_BSDV_VZ, steelSection.Vz);
-            sectionData.SetValue(IRobotBarSectionDataValue.I_BSDV_VPY, steelSection.Vpy);
-            sectionData.SetValue(IRobotBarSectionDataValue.I_BSDV_VPZ, steelSection.Vpz);
-
-            sectionData.CalcNonstdGeometry();
+            return false;
         }
-        
+
         /***************************************************/
     }
 }

--- a/Robot_Adapter/Convert/ToRobot/Properties/SectionProperty_Geometrical.cs
+++ b/Robot_Adapter/Convert/ToRobot/Properties/SectionProperty_Geometrical.cs
@@ -191,22 +191,22 @@ namespace BH.Adapter.Robot
 
         /***************************************************/
 
-        private static void ToRobotGeometricalSection(this AngleProfile section, IMaterialFragment material, IRobotBarSectionData sectionData)
-        {
-            sectionData.Type = IRobotBarSectionType.I_BST_NS_L;
-            sectionData.ShapeType = IRobotBarSectionShapeType.I_BSST_UUAP;
+        //private static void ToRobotGeometricalSection(this AngleProfile section, IMaterialFragment material, IRobotBarSectionData sectionData)
+        //{
+        //    sectionData.Type = IRobotBarSectionType.I_BST_NS_L;
+        //    sectionData.ShapeType = IRobotBarSectionShapeType.I_BSST_UUAP;
 
-            sectionData.MaterialName = material.DescriptionOrName();
+        //    sectionData.MaterialName = material.DescriptionOrName();
 
-            IRobotBarSectionNonstdData nonStdData = sectionData.CreateNonstd(0);
+        //    IRobotBarSectionNonstdData nonStdData = sectionData.CreateNonstd(0);
 
-            nonStdData.SetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_I_H, section.Height - section.FlangeThickness);
-            nonStdData.SetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_I_B, section.Width);
-            nonStdData.SetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_I_TF, section.FlangeThickness);
-            nonStdData.SetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_I_TW, section.WebThickness);
+        //    nonStdData.SetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_I_H, section.Height - section.FlangeThickness);
+        //    nonStdData.SetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_I_B, section.Width);
+        //    nonStdData.SetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_I_TF, section.FlangeThickness);
+        //    nonStdData.SetValue(IRobotBarSectionNonstdDataValue.I_BSNDV_I_TW, section.WebThickness);
 
-            sectionData.CalcNonstdGeometry();
-        }
+        //    sectionData.CalcNonstdGeometry();
+        //}
 
         /***************************************************/
 

--- a/Robot_Adapter/Convert/ToRobot/Properties/SectionProperty_Geometrical.cs
+++ b/Robot_Adapter/Convert/ToRobot/Properties/SectionProperty_Geometrical.cs
@@ -34,9 +34,9 @@ namespace BH.Adapter.Robot
         /****           Public Methods                  ****/
         /***************************************************/
 
-        public static void ToRobot(this SteelSection section, IMaterialFragment material, IRobotBarSectionData secData)
+        public static void ToRobot(this IGeometricalSection section, IMaterialFragment material, IRobotBarSectionData secData)
         {
-            ToRobotSteelSection(section.SectionProfile as dynamic, material, secData);
+            ToRobotGeometricalSection(section.SectionProfile as dynamic, material, secData);
         }
 
         /***************************************************/
@@ -45,7 +45,7 @@ namespace BH.Adapter.Robot
         /****           Private Methods                  ****/
         /***************************************************/
 
-        private static void ToRobotSteelSection(this BoxProfile section, IMaterialFragment material, IRobotBarSectionData sectionData)
+        private static void ToRobotGeometricalSection(this BoxProfile section, IMaterialFragment material, IRobotBarSectionData sectionData)
         {
             sectionData.Type = IRobotBarSectionType.I_BST_NS_RECT;
             sectionData.ShapeType = IRobotBarSectionShapeType.I_BSST_USER_RECT;
@@ -63,7 +63,7 @@ namespace BH.Adapter.Robot
 
         /***************************************************/
 
-        private static void ToRobotSteelSection(this FabricatedBoxProfile section, IMaterialFragment material, IRobotBarSectionData sectionData)
+        private static void ToRobotGeometricalSection(this FabricatedBoxProfile section, IMaterialFragment material, IRobotBarSectionData sectionData)
         {
             sectionData.Type = IRobotBarSectionType.I_BST_NS_BOX_3;
             sectionData.ShapeType = IRobotBarSectionShapeType.I_BSST_USER_BOX_3;
@@ -85,7 +85,7 @@ namespace BH.Adapter.Robot
 
         /***************************************************/
 
-        private static void ToRobotSteelSection(this FabricatedISectionProfile section, IMaterialFragment material, IRobotBarSectionData sectionData)
+        private static void ToRobotGeometricalSection(this FabricatedISectionProfile section, IMaterialFragment material, IRobotBarSectionData sectionData)
         {
             sectionData.Type = IRobotBarSectionType.I_BST_NS_II;
             sectionData.ShapeType = IRobotBarSectionShapeType.I_BSST_USER_I_MONOSYM;
@@ -105,7 +105,7 @@ namespace BH.Adapter.Robot
 
         /***************************************************/
 
-        private static void ToRobotSteelSection(this ISectionProfile section, IMaterialFragment material, IRobotBarSectionData sectionData)
+        private static void ToRobotGeometricalSection(this ISectionProfile section, IMaterialFragment material, IRobotBarSectionData sectionData)
         {
             sectionData.Type = IRobotBarSectionType.I_BST_NS_I;
             sectionData.ShapeType = IRobotBarSectionShapeType.I_BSST_USER_I_BISYM;
@@ -123,7 +123,7 @@ namespace BH.Adapter.Robot
 
         /***************************************************/
 
-        private static void ToRobotSteelSection(this TSectionProfile section, IMaterialFragment material, IRobotBarSectionData sectionData)
+        private static void ToRobotGeometricalSection(this TSectionProfile section, IMaterialFragment material, IRobotBarSectionData sectionData)
         {
             sectionData.Type = IRobotBarSectionType.I_BST_NS_T;
             sectionData.ShapeType = IRobotBarSectionShapeType.I_BSST_USER_T_SHAPE;
@@ -142,7 +142,7 @@ namespace BH.Adapter.Robot
 
         /***************************************************/
 
-        private static void ToRobotSteelSection(this TubeProfile section, IMaterialFragment material, IRobotBarSectionData sectionData)
+        private static void ToRobotGeometricalSection(this TubeProfile section, IMaterialFragment material, IRobotBarSectionData sectionData)
         {
             sectionData.Type = IRobotBarSectionType.I_BST_NS_TUBE;
             sectionData.ShapeType = IRobotBarSectionShapeType.I_BSST_USER_TUBE;
@@ -159,7 +159,7 @@ namespace BH.Adapter.Robot
 
         /***************************************************/
 
-        private static void ToRobotSteelSection(this RectangleProfile section, IMaterialFragment material, IRobotBarSectionData sectionData)
+        private static void ToRobotGeometricalSection(this RectangleProfile section, IMaterialFragment material, IRobotBarSectionData sectionData)
         {
             sectionData.Type = IRobotBarSectionType.I_BST_NS_RECT;
             sectionData.ShapeType = IRobotBarSectionShapeType.I_BSST_RECT_FILLED;
@@ -176,7 +176,7 @@ namespace BH.Adapter.Robot
 
         /***************************************************/
 
-        private static void ToRobotSteelSection(this CircleProfile section, IMaterialFragment material, IRobotBarSectionData sectionData)
+        private static void ToRobotGeometricalSection(this CircleProfile section, IMaterialFragment material, IRobotBarSectionData sectionData)
         {
             sectionData.Type = IRobotBarSectionType.I_BST_NS_TUBE;
             sectionData.ShapeType = IRobotBarSectionShapeType.I_BSST_CIRC_FILLED;
@@ -191,7 +191,7 @@ namespace BH.Adapter.Robot
 
         /***************************************************/
 
-        private static void ToRobotSteelSection(this AngleProfile section, IMaterialFragment material, IRobotBarSectionData sectionData)
+        private static void ToRobotGeometricalSection(this AngleProfile section, IMaterialFragment material, IRobotBarSectionData sectionData)
         {
             sectionData.Type = IRobotBarSectionType.I_BST_NS_L;
             sectionData.ShapeType = IRobotBarSectionShapeType.I_BSST_UUAP;
@@ -210,7 +210,7 @@ namespace BH.Adapter.Robot
 
         /***************************************************/
 
-        private static void ToRobotSteelSection(this ChannelProfile section, IMaterialFragment material, IRobotBarSectionData sectionData)
+        private static void ToRobotGeometricalSection(this ChannelProfile section, IMaterialFragment material, IRobotBarSectionData sectionData)
         {
             sectionData.Type = IRobotBarSectionType.I_BST_NS_C;
             sectionData.ShapeType = IRobotBarSectionShapeType.I_BSST_USER_C_SHAPE;
@@ -229,7 +229,7 @@ namespace BH.Adapter.Robot
 
         /***************************************************/
 
-        private static void ToRobotSteelSection(this GeneralisedFabricatedBoxProfile section, IMaterialFragment material, IRobotBarSectionData sectionData)
+        private static void ToRobotGeometricalSection(this GeneralisedFabricatedBoxProfile section, IMaterialFragment material, IRobotBarSectionData sectionData)
         {
             sectionData.Type = IRobotBarSectionType.I_BST_NS_BOX_3;
             sectionData.ShapeType = IRobotBarSectionShapeType.I_BSST_USER_BOX_3;
@@ -253,12 +253,12 @@ namespace BH.Adapter.Robot
 
         /***************************************************/
 
-        private static void ToRobotSteelSection(this IProfile section, IMaterialFragment material, IRobotBarSectionData sectionData)
+        private static void ToRobotGeometricalSection(this IProfile section, IMaterialFragment material, IRobotBarSectionData sectionData)
         {
             BH.Engine.Reflection.Compute.RecordWarning("Profile of type " + section.GetType().Name + "is not yet fully supported for Steel sections. Section with name " + sectionData.Name + " set as explicit section");
 
             sectionData.MaterialName = material.DescriptionOrName();
-            SteelSection steelSection = BH.Engine.Structure.Create.SteelSectionFromProfile(section, material as Steel);
+            IGeometricalSection steelSection = Create.SectionPropertyFromProfile(section, material as Steel);
 
             sectionData.SetValue(IRobotBarSectionDataValue.I_BSDV_AX, steelSection.Area);
             sectionData.SetValue(IRobotBarSectionDataValue.I_BSDV_IX, steelSection.J);

--- a/Robot_Adapter/Convert/ToRobot/Properties/SectionProperty_Geometrical.cs
+++ b/Robot_Adapter/Convert/ToRobot/Properties/SectionProperty_Geometrical.cs
@@ -260,7 +260,7 @@ namespace BH.Adapter.Robot
 
         private static bool ToRobotGeometricalSection(this IProfile section, IRobotBarSectionData sectionData)
         {
-            BH.Engine.Reflection.Compute.RecordWarning("Profile of type " + section.GetType().Name + "is not yet fully supported for Steel sections. Section with name " + sectionData.Name + " set as explicit section");
+            BH.Engine.Reflection.Compute.RecordWarning("Profile of type " + section.GetType().Name + " is not yet fully supported for Steel sections. Section with name " + sectionData.Name + " set as explicit section");
             return false;
         }
 

--- a/Robot_Adapter/Robot_Adapter.csproj
+++ b/Robot_Adapter/Robot_Adapter.csproj
@@ -186,8 +186,8 @@
     <Compile Include="Convert\FromRobot\Properties\SectionProperty.cs" />
     <Compile Include="Convert\FromRobot\Properties\Support.cs" />
     <Compile Include="Convert\FromRobot\Properties\SurfaceProperty.cs" />
-    <Compile Include="Convert\FromRobot\Properties\SectionProperty_Concrete.cs" />
-    <Compile Include="Convert\FromRobot\Properties\SectionProperty_Steel.cs" />
+    <Compile Include="Convert\FromRobot\Properties\SectionProfile_Concrete.cs" />
+    <Compile Include="Convert\FromRobot\Properties\SectionProfile_General.cs" />
     <Compile Include="Convert\FromRobot\Groups and Lists\Selections.cs" />
     <Compile Include="Convert\ToRobot\Elements\Bar.cs" />
     <Compile Include="Convert\ToRobot\Geometry\Point.cs" />
@@ -202,7 +202,7 @@
     <Compile Include="Convert\ToRobot\Properties\LinearRelease.cs" />
     <Compile Include="Convert\ToRobot\Properties\SurfaceProperty.cs" />
     <Compile Include="Convert\ToRobot\Properties\SectionProperty_Concrete.cs" />
-    <Compile Include="Convert\ToRobot\Properties\SectionProperty_Steel.cs" />
+    <Compile Include="Convert\ToRobot\Properties\SectionProperty_Geometrical.cs" />
     <Compile Include="Convert\ToRobot\Properties\Support.cs" />
     <Compile Include="Convert\ToRobot\Properties\BarRelease.cs" />
     <Compile Include="Convert\ToRobot\Properties\SectionProperty.cs" />


### PR DESCRIPTION
 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #342 
Closes #314 
Closes #156 
Closes #297 
Closes #325 
Closes #274 

 <!-- Add short description of what has been fixed -->

Some general cleanup of section push and especially pull. Closing out quite a few nagging issues.

 ### Test files
<!-- Link to test files to validate the proposed changes -->

Some testfiles in here, will populate with more:

https://burohappold.sharepoint.com/:f:/s/BHoM/EtJy7X25ROVPlFSKYiXSO4kBgmM87FHIO1Tg6yz7qxJ25Q?e=aV0rj1

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->

- General support for Explcit sections on Read
- Return an explicit section with analytical properties set (if existing) if failing to extract/convert the ShapeProfile when reading sections
- Return all Section and Thickness labels in the model, including ones not attached to elements when reading
- Support for pushing and pulling all IGeometrical sections. Some outstanding capabilities awaiting improvements to material handling.

 ### Additional comments
<!-- As required -->
