### PR TITLE
Add pull capability for all materials

### DIFF
--- a/Robot_Adapter/CRUD/Read/Read.cs
+++ b/Robot_Adapter/CRUD/Read/Read.cs
@@ -33,6 +33,7 @@ using BH.oM.Physical.Materials;
 using BH.oM.Adapters.Robot;
 using BH.oM.Structure.Results;
 using BH.oM.Common;
+using BH.oM.Structure.MaterialFragments;
 using BH.oM.Data.Requests;
 using System.Linq;
 using BH.oM.Adapter;

--- a/Robot_Adapter/CRUD/Read/Read.cs
+++ b/Robot_Adapter/CRUD/Read/Read.cs
@@ -36,6 +36,7 @@ using BH.oM.Common;
 using BH.oM.Data.Requests;
 using System.Linq;
 using BH.oM.Adapter;
+using BH.oM.Structure.MaterialFragments;
 
 namespace BH.Adapter.Robot
 {
@@ -62,7 +63,7 @@ namespace BH.Adapter.Robot
             if (type == typeof(Constraint6DOF))
                 return ReadConstraints6DOF();
         
-            if (type == typeof(Material))
+            if (typeof(IMaterialFragment).IsAssignableFrom(type))
                 return ReadMaterials();
 
             if (type == typeof(Panel))

--- a/Robot_Adapter/Convert/FromRobot/Properties/Material.cs
+++ b/Robot_Adapter/Convert/FromRobot/Properties/Material.cs
@@ -35,7 +35,7 @@ namespace BH.Adapter.Robot
 
         public static IMaterialFragment FromRobot(this IRobotLabel robotLabel, IRobotMaterialData robotLabelData, string name = "")
         {
-            if(robotLabel.Name != "") name = robotLabel.Name;
+            if (robotLabel.Name != "") name = robotLabel.Name;
             IMaterialFragment material;
             switch (robotLabelData.Type)
             {
@@ -55,10 +55,13 @@ namespace BH.Adapter.Robot
                     material = Engine.Structure.Create.Timber(name, Create.Vector(robotLabelData.E, robotLabelData.E_Trans, robotLabelData.E_Trans), Create.Vector(robotLabelData.NU, robotLabelData.NU, robotLabelData.NU), Create.Vector(robotLabelData.Kirchoff, robotLabelData.Kirchoff, robotLabelData.Kirchoff), Create.Vector(robotLabelData.LX, robotLabelData.LX, robotLabelData.LX), robotLabelData.RO / Engine.Robot.Query.RobotGravityConstant, robotLabelData.DumpCoef);
                     break;
                 case IRobotMaterialType.I_MT_ALL:
+                    material = new GenericIsotropicMaterial { Density = robotLabelData.RO / Engine.Robot.Query.RobotGravityConstant, DampingRatio = robotLabelData.DumpCoef, PoissonsRatio = robotLabelData.NU, ThermalExpansionCoeff = robotLabelData.LX, YoungsModulus = robotLabelData.E, EmbodiedCarbon = 0 };
+                    break;
+
                 default:
                     Engine.Reflection.Compute.RecordWarning("Material named '" + name + "' of Robot type " + robotLabelData.Type + " not yet suported. Empty material will be provided");
                     return null;
-            }           
+            }
             return material;
         }
 

--- a/Robot_Adapter/Convert/FromRobot/Properties/Material.cs
+++ b/Robot_Adapter/Convert/FromRobot/Properties/Material.cs
@@ -23,6 +23,7 @@
 using System.Collections.Generic;
 using RobotOM;
 using BH.oM.Structure.MaterialFragments;
+using BH.Engine.Geometry;
 
 namespace BH.Adapter.Robot
 {
@@ -48,7 +49,11 @@ namespace BH.Adapter.Robot
                     material = Engine.Structure.Create.Aluminium(name, robotLabelData.E, robotLabelData.NU, robotLabelData.LX, robotLabelData.RO / Engine.Robot.Query.RobotGravityConstant, robotLabelData.DumpCoef);
                     break;
                 case IRobotMaterialType.I_MT_OTHER:
+                    material = new GenericIsotropicMaterial { Density = robotLabelData.RO / Engine.Robot.Query.RobotGravityConstant, DampingRatio = robotLabelData.DumpCoef, PoissonsRatio = robotLabelData.NU, ThermalExpansionCoeff = robotLabelData.LX, YoungsModulus = robotLabelData.E, EmbodiedCarbon = 0 }; 
+                    break;
                 case IRobotMaterialType.I_MT_TIMBER:
+                    material = Engine.Structure.Create.Timber(name, Create.Vector(robotLabelData.E, robotLabelData.E_Trans, robotLabelData.E_Trans), Create.Vector(robotLabelData.NU, robotLabelData.NU, robotLabelData.NU), Create.Vector(robotLabelData.Kirchoff, robotLabelData.Kirchoff, robotLabelData.Kirchoff), Create.Vector(robotLabelData.LX, robotLabelData.LX, robotLabelData.LX), robotLabelData.RO / Engine.Robot.Query.RobotGravityConstant, robotLabelData.DumpCoef);
+                    break;
                 case IRobotMaterialType.I_MT_ALL:
                 default:
                     Engine.Reflection.Compute.RecordWarning("Material named '" + name + "' of Robot type " + robotLabelData.Type + " not yet suported. Empty material will be provided");

--- a/Robot_Adapter/Convert/FromRobot/Properties/Material.cs
+++ b/Robot_Adapter/Convert/FromRobot/Properties/Material.cs
@@ -48,19 +48,14 @@ namespace BH.Adapter.Robot
                 case IRobotMaterialType.I_MT_ALUMINIUM:
                     material = Engine.Structure.Create.Aluminium(name, robotLabelData.E, robotLabelData.NU, robotLabelData.LX, robotLabelData.RO / Engine.Robot.Query.RobotGravityConstant, robotLabelData.DumpCoef);
                     break;
-                case IRobotMaterialType.I_MT_OTHER:
-                    material = new GenericIsotropicMaterial { Density = robotLabelData.RO / Engine.Robot.Query.RobotGravityConstant, DampingRatio = robotLabelData.DumpCoef, PoissonsRatio = robotLabelData.NU, ThermalExpansionCoeff = robotLabelData.LX, YoungsModulus = robotLabelData.E, EmbodiedCarbon = 0 }; 
-                    break;
                 case IRobotMaterialType.I_MT_TIMBER:
                     material = Engine.Structure.Create.Timber(name, Create.Vector(robotLabelData.E, robotLabelData.E_Trans, robotLabelData.E_Trans), Create.Vector(robotLabelData.NU, robotLabelData.NU, robotLabelData.NU), Create.Vector(robotLabelData.Kirchoff, robotLabelData.Kirchoff, robotLabelData.Kirchoff), Create.Vector(robotLabelData.LX, robotLabelData.LX, robotLabelData.LX), robotLabelData.RO / Engine.Robot.Query.RobotGravityConstant, robotLabelData.DumpCoef);
                     break;
+                case IRobotMaterialType.I_MT_OTHER:
                 case IRobotMaterialType.I_MT_ALL:
+                default:
                     material = new GenericIsotropicMaterial { Density = robotLabelData.RO / Engine.Robot.Query.RobotGravityConstant, DampingRatio = robotLabelData.DumpCoef, PoissonsRatio = robotLabelData.NU, ThermalExpansionCoeff = robotLabelData.LX, YoungsModulus = robotLabelData.E, EmbodiedCarbon = 0 };
                     break;
-
-                default:
-                    Engine.Reflection.Compute.RecordWarning("Material named '" + name + "' of Robot type " + robotLabelData.Type + " not yet suported. Empty material will be provided");
-                    return null;
             }
             return material;
         }


### PR DESCRIPTION
Added pull functionality for Timber and User-defined materials.

<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->



 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #345 

 <!-- Add short description of what has been fixed -->


 ### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/Robot_Toolkit/Pull%20Requests/Robot_Toolkit_Add_pull_capability_for_all_material_types?csf=1&web=1&e=lA2Qcd

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->
