### PR TITLE
Make modifiers use new Fragment

### DIFF
--- a/Robot_Adapter/Convert/FromRobot/Properties/SurfaceProperty.cs
+++ b/Robot_Adapter/Convert/FromRobot/Properties/SurfaceProperty.cs
@@ -26,6 +26,7 @@ using System;
 using System.Collections.Generic;
 using BH.oM.Structure.SurfaceProperties;
 using BH.Engine.Structure;
+using BH.oM.Structure.Fragments;
 
 namespace BH.Adapter.Robot
 {
@@ -81,7 +82,7 @@ namespace BH.Adapter.Robot
                                 BHoMProperty = new ConstantThickness { Name = robotLabelName, Thickness = orthoData.H, Material = mat };
                                 double n1 = orthoData.N1;
                                 double n2 = orthoData.N2;
-                                BHoMProperty.ApplyModifiers(n1, Math.Sqrt(n1 + n2), n2, n1, Math.Sqrt(n1 + n2), n2, n1, n2);
+                                BHoMProperty = BHoMProperty.ApplyModifiers(n1, Math.Sqrt(n1 + n2), n2, n1, Math.Sqrt(n1 + n2), n2, n1, n2);
                                 break;
                             case IRobotThicknessOrthoType.I_TOT_UNIDIR_BOX_FLOOR:
                             case IRobotThicknessOrthoType.I_TOT_SLAB_ON_TRAPEZOID_PLATE:
@@ -94,7 +95,20 @@ namespace BH.Adapter.Robot
                                 break;
                             default:
                                 BHoMProperty = new ConstantThickness { Name = robotLabelName, Thickness = orthoData.H, Material = mat };
-                                BHoMProperty.ApplyModifiers(orthoData.HA, orthoData.H0, orthoData.HB, orthoData.HC, orthoData.A, orthoData.A1, orthoData.A2, orthoData.B, 1, orthoData.B1);
+                                SurfacePropertyModifier modifier = new SurfacePropertyModifier
+                                {
+                                    FXX = orthoData.HA,
+                                    FXY = orthoData.HB,
+                                    FYY = orthoData.H0,
+                                    MXX = orthoData.HC,
+                                    MXY = orthoData.A,
+                                    MYY = orthoData.A1,
+                                    VXZ = orthoData.A2,
+                                    VYZ = orthoData.B,
+                                    Mass = 1,   //Cant extract mass via the API
+                                    Weight = orthoData.B1
+                                };
+                                BHoMProperty.Fragments.Add(modifier);
                                 break;
                         }
                         break;

--- a/Robot_Adapter/Convert/ToRobot/Properties/SurfaceProperty.cs
+++ b/Robot_Adapter/Convert/ToRobot/Properties/SurfaceProperty.cs
@@ -27,6 +27,8 @@ using System;
 using System.Collections.Generic;
 using BH.oM.Structure.Elements;
 using BH.oM.Structure.SurfaceProperties;
+using BH.oM.Structure.Fragments;
+using BH.Engine.Base;
 
 namespace BH.Adapter.Robot
 {
@@ -53,22 +55,25 @@ namespace BH.Adapter.Robot
                 if (property is ConstantThickness)
                 {
                     ConstantThickness constThickness = property as ConstantThickness;
-                    if (BH.Engine.Structure.Query.HasModifiers(property))
+                    SurfacePropertyModifier modifier = property.FindFragment<SurfacePropertyModifier>();
+                    if (modifier != null)
                     {
                         thicknessData.ThicknessType = IRobotThicknessType.I_TT_ORTHOTROPIC;
                         orthoData = thicknessData.Data;
-                        orthoData.Type = (IRobotThicknessOrthoType)14;
+                        orthoData.Type = IRobotThicknessOrthoType.I_TOT_CONST_THICK_WITH_REDUCED_STIFFNESS;
                         orthoData.H = constThickness.Thickness;
-                        double[] modifiers = BH.Engine.Structure.Query.Modifiers(constThickness);
-                        orthoData.HA = modifiers[(int)PanelModifier.f11];
-                        orthoData.H0 = modifiers[(int)PanelModifier.f12];
-                        orthoData.HB = modifiers[(int)PanelModifier.f22];
-                        orthoData.HC = modifiers[(int)PanelModifier.m11];
-                        orthoData.A = modifiers[(int)PanelModifier.m12];
-                        orthoData.A1 = modifiers[(int)PanelModifier.m22];
-                        orthoData.A2 = modifiers[(int)PanelModifier.v13];
-                        orthoData.B = modifiers[(int)PanelModifier.v23];
-                        orthoData.B1 = modifiers[(int)PanelModifier.Weight];
+                        orthoData.HA = modifier.FXX;
+                        orthoData.H0 = modifier.FYY;
+                        orthoData.HB = modifier.FXY;
+                        orthoData.HC = modifier.MXX;
+                        orthoData.A = modifier.MXY;
+                        orthoData.A1 = modifier.MYY;
+                        orthoData.A2 = modifier.VXZ;
+                        orthoData.B = modifier.VYZ;
+                        orthoData.B1 = modifier.Weight;
+
+                        if (modifier.Mass != 1)
+                            Engine.Reflection.Compute.RecordNote("Can't apply modifier for mass for SurfaceProperties via the Robot API.");
                     }
                     else
                     {

--- a/Robot_Adapter/Convert/ToRobot/Properties/SurfaceProperty.cs
+++ b/Robot_Adapter/Convert/ToRobot/Properties/SurfaceProperty.cs
@@ -107,6 +107,7 @@ namespace BH.Adapter.Robot
                     orthoData.HA = ribbed.TotalDepth;
                     orthoData.A = ribbed.Spacing;
                     orthoData.A1 = ribbed.StemWidth;
+                    orthoData.DirType = ribbed.Direction == PanelDirection.X ? IRobotThicknessOrthoDirType.I_TODT_DIR_X : IRobotThicknessOrthoDirType.I_TODT_DIR_Y;
                 }
             }
             return name;          

--- a/Robot_Adapter/Convert/ToRobot/Properties/SurfaceProperty.cs
+++ b/Robot_Adapter/Convert/ToRobot/Properties/SurfaceProperty.cs
@@ -87,7 +87,7 @@ namespace BH.Adapter.Robot
                     Waffle waffle = property as Waffle;
                     thicknessData.ThicknessType = IRobotThicknessType.I_TT_ORTHOTROPIC;
                     orthoData = thicknessData.Data;
-                    orthoData.Type = (IRobotThicknessOrthoType)14;
+                    orthoData.Type = IRobotThicknessOrthoType.I_TOT_ONE_SIDED_BIDIR_RIBS;
                     orthoData.H = waffle.Thickness;
                     orthoData.HA = waffle.TotalDepthX;
                     orthoData.HB = waffle.TotalDepthY;
@@ -102,7 +102,7 @@ namespace BH.Adapter.Robot
                     Ribbed ribbed = property as Ribbed;
                     thicknessData.ThicknessType = IRobotThicknessType.I_TT_ORTHOTROPIC;
                     orthoData = thicknessData.Data;
-                    orthoData.Type = (IRobotThicknessOrthoType)14;
+                    orthoData.Type = IRobotThicknessOrthoType.I_TOT_ONE_SIDED_UNIDIR_RIBS;
                     orthoData.H = ribbed.Thickness;
                     orthoData.HA = ribbed.TotalDepth;
                     orthoData.A = ribbed.Spacing;


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

https://github.com/BHoM/BHoM/pull/895
https://github.com/BHoM/BHoM_Engine/pull/1809

 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #376
Closes #378 

 <!-- Add short description of what has been fixed -->

- Make use of the new Modifer fragments that formalises better the handling of modifiers for section and surface properties.
- Fixes issue with wrong enum being used when pushing Rib and Waffle slabs.
 ### Test files
<!-- Link to test files to validate the proposed changes -->

https://burohappold.sharepoint.com/:f:/s/BHoM/EhBi9qlwov1DhC_IYlKPdyYBsxSjJ81794LuJdwKo-R_PQ?e=34V502

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->
