### PR TITLE
Fixing robot BarForce signs flipped

### DIFF
--- a/Robot_Adapter/CRUD/Read/Results/BarResults.cs
+++ b/Robot_Adapter/CRUD/Read/Results/BarResults.cs
@@ -163,7 +163,7 @@ namespace BH.Adapter.Robot
             double my = TryGetValue(row, (int)IRobotExtremeValueType.I_EVT_FORCE_BAR_MY);
             double mz = TryGetValue(row, (int)IRobotExtremeValueType.I_EVT_FORCE_BAR_MZ);
 
-            return new BarForce(idBar, idCase, mode, 0, position, divisions, fx, fy, fz, mx, my, mz);
+            return new BarForce(idBar, idCase, mode, 0, position, divisions, -fx, -fy, -fz, -mx, -my, mz);
         }
 
         /***************************************************/

--- a/Robot_Adapter/CRUD/Read/Results/BarResults.cs
+++ b/Robot_Adapter/CRUD/Read/Results/BarResults.cs
@@ -163,7 +163,7 @@ namespace BH.Adapter.Robot
             double my = TryGetValue(row, (int)IRobotExtremeValueType.I_EVT_FORCE_BAR_MY);
             double mz = TryGetValue(row, (int)IRobotExtremeValueType.I_EVT_FORCE_BAR_MZ);
 
-            return new BarForce(idBar, idCase, mode, 0, position, divisions, -fx, -fy, -fz, -mx, -my, mz);
+            return new BarForce(idBar, idCase, mode, 0, position, divisions, -fx, fy, fz, mx, -my, mz);
         }
 
         /***************************************************/


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #397

 <!-- Add short description of what has been fixed -->

As stated in issue, somewhere in refactoring, the sign change for the values of the BarForce where being missed. Adding those signs previously used back in.

 ### Test files
<!-- Link to test files to validate the proposed changes -->

https://burohappold.sharepoint.com/:f:/s/BHoM/EqqZu_1Sr0lIkfBdRPg8TBQBBsLM3bh3YedOFyiiI5-_tA?e=FnxOW6

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->
