### PR TITLE
Null checks when reading bars and avoid pulling of 'Super bars'

### DIFF
--- a/Robot_Adapter/CRUD/Read/Elements/Bars.cs
+++ b/Robot_Adapter/CRUD/Read/Elements/Bars.cs
@@ -129,7 +129,7 @@ namespace BH.Adapter.Robot
 
         private void SuperBarWarning()
         {
-            Engine.Reflection.Compute.RecordWarning("Model contains 'Super Bars' which are not extracted. Reading Bars only extracts the idividual bar segments.");
+            Engine.Reflection.Compute.RecordWarning("Model contains 'Super Bars' which are not extracted. Reading Bars only extracts the individual bar segments.");
         }
 
         /***************************************************/
@@ -256,5 +256,4 @@ namespace BH.Adapter.Robot
     }
 
 }
-
 

--- a/Robot_Adapter/CRUD/Read/Elements/Bars.cs
+++ b/Robot_Adapter/CRUD/Read/Elements/Bars.cs
@@ -69,18 +69,25 @@ namespace BH.Adapter.Robot
                 for (int i = 1; i <= robotBars.Count; i++)
                 {
                     RobotBar robotBar = robotBars.Get(i);
-                    Bar bhomBar = Convert.FromRobot( robotBar, 
-                                                     bhomNodes, 
-                                                     bhomSections, 
-                                                     bhomMaterial, 
-                                                     bhombarReleases,
-                                                     offsets,
-                                                     bhomFramEleDesProps,
-                                                     ref sectionWithMaterial);
-                    bhomBar.CustomData[AdapterIdName] = robotBar.Number;
-                    if (barTags != null && barTags.TryGetValue(robotBar.Number, out tags))
-                        bhomBar.Tags = tags;
-                    bhomBars.Add(bhomBar);
+                    if (!robotBar.IsSuperBar)
+                    {
+                        Bar bhomBar = Convert.FromRobot(robotBar,
+                                                         bhomNodes,
+                                                         bhomSections,
+                                                         bhomMaterial,
+                                                         bhombarReleases,
+                                                         offsets,
+                                                         bhomFramEleDesProps,
+                                                         ref sectionWithMaterial);
+                        bhomBar.CustomData[AdapterIdName] = robotBar.Number;
+                        if (barTags != null && barTags.TryGetValue(robotBar.Number, out tags))
+                            bhomBar.Tags = tags;
+                        bhomBars.Add(bhomBar);
+                    }
+                    else
+                    {
+                        SuperBarWarning();
+                    }
                 }
             }
             else
@@ -88,7 +95,9 @@ namespace BH.Adapter.Robot
                 for (int i = 0; i < barIds.Count; i++)
                 {
                     RobotBar robotBar = m_RobotApplication.Project.Structure.Bars.Get(barIds[i]) as RobotBar;
-                    Bar bhomBar = Convert.FromRobot( robotBar, 
+                    if (!robotBar.IsSuperBar)
+                    {
+                        Bar bhomBar = Convert.FromRobot( robotBar, 
                                                      bhomNodes, 
                                                      bhomSections, 
                                                      bhomMaterial,
@@ -100,6 +109,11 @@ namespace BH.Adapter.Robot
                     if (barTags != null && barTags.TryGetValue(robotBar.Number, out tags))
                         bhomBar.Tags = tags;
                     bhomBars.Add(bhomBar);
+                    }
+                    else
+                    {
+                        SuperBarWarning();
+                    }
                 }
             }
             m_RobotApplication.Project.Structure.Bars.EndMultiOperation();
@@ -108,6 +122,14 @@ namespace BH.Adapter.Robot
             PostProcessBarSections(sectionWithMaterial);
 
             return bhomBars;
+        }
+
+        /***************************************************/
+
+
+        private void SuperBarWarning()
+        {
+            Engine.Reflection.Compute.RecordWarning("Model contains 'Super Bars' which are not extracted. Reading Bars only extracts the idividual bar segments.");
         }
 
         /***************************************************/

--- a/Robot_Adapter/Convert/FromRobot/Elements/Bar.cs
+++ b/Robot_Adapter/Convert/FromRobot/Elements/Bar.cs
@@ -183,6 +183,10 @@ namespace BH.Adapter.Robot
 
         public static double FromRobotOrientationAngle(this Bar bhomBar, double robotOrientation)
         {
+            //Check that bar nodes have been set
+            if (bhomBar.StartNode == null || bhomBar.EndNode == null || bhomBar.StartNode.Position == null || bhomBar.EndNode.Position == null)
+                return robotOrientation;
+
             //Check vertical status
             bool bhomVertical = bhomBar.IsVertical();
             bool robotVertical = bhomBar.IsVerticalRobot();

--- a/Robot_Adapter/Convert/ToRobot/Loads/ILoad.cs
+++ b/Robot_Adapter/Convert/ToRobot/Loads/ILoad.cs
@@ -34,7 +34,7 @@ namespace BH.Adapter.Robot
         public static void ToRobot(ILoad load, RobotSimpleCase sCase, RobotGroupServer rGroupServer)
         {
             if(load != null)
-                BH.Engine.Reflection.Compute.RecordWarning("Load of type '" + load.GetType() + "' not supported");
+                BH.Engine.Reflection.Compute.RecordError("Load of type '" + load.GetType() + "' not supported");
         }
 
         /***************************************************/


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #401 
Closes #402 

 <!-- Add short description of what has been fixed -->


 ### Test files
<!-- Link to test files to validate the proposed changes -->

https://burohappold.sharepoint.com/:f:/s/BHoM/Ev4xpwQvlFtAhZEA37LejXwBb2DKOJaoc81oQbczrqLQDQ?e=JYEN2h

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->

- Add null checks for nodes before evaluating if a bar is vertical
- Only pull single segment bars, and raise warning for SuperBars

 ### Additional comments
<!-- As required -->
