### PR TITLE
Update index extraction of secondary nodes

### DIFF
--- a/Robot_Adapter/CRUD/Read/Elements/RigidLinks.cs
+++ b/Robot_Adapter/CRUD/Read/Elements/RigidLinks.cs
@@ -46,7 +46,7 @@ namespace BH.Adapter.Robot
             List<RigidLink> bhomRigidLinks = new List<RigidLink>();
 
             IEnumerable<Node> bhomNodesList = ReadNodes();
-            Dictionary<string, Node> bhomNodes = bhomNodesList.ToDictionary(x => x.CustomData[AdapterIdName].ToString());
+            Dictionary<int, Node> bhomNodes = bhomNodesList.ToDictionary(x => System.Convert.ToInt32(x.CustomData[AdapterIdName]));
             Dictionary<string, LinkConstraint> bhomLinkConstraints = ReadLinkConstraint().ToDictionary(x => x.Name.ToString());
 
             if (linksIds == null || linksIds.Count == 0)
@@ -56,9 +56,9 @@ namespace BH.Adapter.Robot
                     IRobotNodeRigidLinkDef robotRigidLink = m_RobotApplication.Project.Structure.Nodes.RigidLinks.Get(i) as IRobotNodeRigidLinkDef;
 
                     RigidLink bhomRigidLink = new RigidLink();
-                    bhomRigidLink.PrimaryNode = bhomNodes[robotRigidLink.Master.ToString()];
+                    bhomRigidLink.PrimaryNode = bhomNodes[robotRigidLink.Master];
 
-                    string[] secondaryIds = robotRigidLink.Slaves.Split(',').Select(sl => sl.Replace(" ","")).ToArray();
+                    List<int> secondaryIds = Convert.FromRobotSelectionString(robotRigidLink.Slaves);
                
                     bhomRigidLink.SecondaryNodes = secondaryIds.Select(sl => bhomNodes[sl]).ToList();
 
@@ -76,9 +76,10 @@ namespace BH.Adapter.Robot
                     IRobotNodeRigidLinkDef robotRigidLink = m_RobotApplication.Project.Structure.Nodes.RigidLinks.Get(linksIds[i]) as IRobotNodeRigidLinkDef;
 
                     RigidLink bhomRigidLink = new RigidLink();
-                    bhomRigidLink.PrimaryNode = bhomNodes[robotRigidLink.Master.ToString()];
+                    bhomRigidLink.PrimaryNode = bhomNodes[robotRigidLink.Master];
 
-                    string[] secondaryIds = robotRigidLink.Slaves.Split(',');
+                    List<int> secondaryIds = Convert.FromRobotSelectionString(robotRigidLink.Slaves);
+
                     bhomRigidLink.SecondaryNodes = secondaryIds.Select(sl => bhomNodes[sl]).ToList();
 
                     bhomRigidLink.Constraint = bhomLinkConstraints[robotRigidLink.LabelName];


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #407

 <!-- Add short description of what has been fixed -->

Fixes a bug in Robot when reading some rigid links types, when the indices of the secondary nodes where formatted in a specific format.

 ### Test files
<!-- Link to test files to validate the proposed changes -->

Multiadapter test file:

https://burohappold.sharepoint.com/:f:/s/BHoM/EqpSv-bKRo1MgADKuXpcFjwBiGwtfUg0DaP8OAr2fcuSwQ?e=zRBofu

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->
