### PR TITLE
Fix filtering ids when pulling

### DIFF
--- a/Robot_Adapter/CRUD/Read/Elements/Bars.cs
+++ b/Robot_Adapter/CRUD/Read/Elements/Bars.cs
@@ -48,7 +48,7 @@ namespace BH.Adapter.Robot
 
         private List<Bar> ReadBars(IList ids = null)
         {
-            List<int> barIds = CheckAndGetIds(ids);
+            List<int> barIds = CheckAndGetIds<Bar>(ids);
 
             List<Bar> bhomBars = new List<Bar>();
             IEnumerable<Node> bhomNodesList = ReadNodes();
@@ -194,7 +194,7 @@ namespace BH.Adapter.Robot
             if (ids == null || ids.Count == 0)
                 bar_sel.FromText("all");
             else
-                bar_sel.FromText(Convert.ToRobotSelectionString(CheckAndGetIds(ids)));
+                bar_sel.FromText(Convert.ToRobotSelectionString(CheckAndGetIds<Bar>(ids)));
 
 
 

--- a/Robot_Adapter/CRUD/Read/Elements/Nodes.cs
+++ b/Robot_Adapter/CRUD/Read/Elements/Nodes.cs
@@ -36,7 +36,7 @@ namespace BH.Adapter.Robot
 
         private List<Node> ReadNodes(IList ids = null)
         {
-            List<int> nodeIds = CheckAndGetIds(ids);
+            List<int> nodeIds = CheckAndGetIds<Node>(ids);
             List<Node> bhomNodes = new List<Node>();
             List<Constraint6DOF> constraints = ReadConstraints6DOF();
             Dictionary<int, HashSet<string>> nodeTags = GetTypeTags(typeof(Node));

--- a/Robot_Adapter/CRUD/Read/Elements/Openings.cs
+++ b/Robot_Adapter/CRUD/Read/Elements/Openings.cs
@@ -40,7 +40,7 @@ namespace BH.Adapter.Robot
             IRobotStructure rStructure = m_RobotApplication.Project.Structure;
             RobotSelection rSelect = rStructure.Selections.Create(IRobotObjectType.I_OT_GEOMETRY);
 
-            List<int> openingIds = CheckAndGetIds(ids);
+            List<int> openingIds = CheckAndGetIds<Opening>(ids);
 
             if (openingIds == null)
             {

--- a/Robot_Adapter/CRUD/Read/Elements/Panels.cs
+++ b/Robot_Adapter/CRUD/Read/Elements/Panels.cs
@@ -53,7 +53,7 @@ namespace BH.Adapter.Robot
 
             Panel panel = null;
 
-            List<int> panelIds = CheckAndGetIds(ids);
+            List<int> panelIds = CheckAndGetIds<Panel>(ids);
 
             RobotSelection robotPanelSelection = robotStructureServer.Selections.Create(IRobotObjectType.I_OT_PANEL);
             RobotSelection robotCladdingPanelSelection = robotStructureServer.Selections.Create(IRobotObjectType.I_OT_GEOMETRY);
@@ -205,7 +205,7 @@ namespace BH.Adapter.Robot
             List<Panel> BHoMPanels = new List<Panel>();
             Panel panel = null;
 
-            List<int> panelIds = CheckAndGetIds(ids);
+            List<int> panelIds = CheckAndGetIds<Panel>(ids);
             RobotSelection rPanSelect = robotStructureServer.Selections.Create(IRobotObjectType.I_OT_PANEL);
             if (panelIds == null)
             {

--- a/Robot_Adapter/CRUD/Read/Elements/RigidLinks.cs
+++ b/Robot_Adapter/CRUD/Read/Elements/RigidLinks.cs
@@ -42,7 +42,7 @@ namespace BH.Adapter.Robot
 
         private List<RigidLink> ReadRigidLinks(IList ids = null)
         {
-            List<int> linksIds = CheckAndGetIds(ids);
+            List<int> linksIds = CheckAndGetIds<RigidLink>(ids);
             List<RigidLink> bhomRigidLinks = new List<RigidLink>();
 
             IEnumerable<Node> bhomNodesList = ReadNodes();

--- a/Robot_Adapter/CRUD/Read/Read.cs
+++ b/Robot_Adapter/CRUD/Read/Read.cs
@@ -162,7 +162,7 @@ namespace BH.Adapter.Robot
 
         /***************************************************/
 
-        private List<int> CheckAndGetIds(IList ids)
+        private List<int> CheckAndGetIds<T>(IEnumerable ids) where T : IBHoMObject
         {
             if (ids == null)
             {
@@ -170,28 +170,22 @@ namespace BH.Adapter.Robot
             }
             else
             {
-                if (ids is List<string>)
-                    return (ids as List<string>).Select(x => int.Parse(x)).ToList();
-                else if (ids is List<int>)
-                    return ids as List<int>;
-                else if (ids is List<double>)
-                    return (ids as List<double>).Select(x => (int)Math.Round(x)).ToList();
-                else
+                List<int> idsOut = new List<int>();
+                foreach (object o in ids)
                 {
-                    List<int> idsOut = new List<int>();
-                    foreach (object o in ids)
+                    int id;
+                    object idObj;
+
+                    if (o is int)
+                        idsOut.Add((int)o);
+                    if (int.TryParse(o.ToString(), out id))
                     {
-                        int id;
-                        object idObj;
-                        if (int.TryParse(o.ToString(), out id))
-                        {
-                            idsOut.Add(id);
-                        }
-                        else if (o is IBHoMObject && (o as IBHoMObject).CustomData.TryGetValue(AdapterIdName, out idObj) && int.TryParse(idObj.ToString(), out id))
-                            idsOut.Add(id);
+                        idsOut.Add(id);
                     }
-                    return idsOut;
+                    else if (o is T && ((T)o).CustomData.TryGetValue(AdapterIdName, out idObj) && int.TryParse(idObj.ToString(), out id))
+                        idsOut.Add(id);
                 }
+                return idsOut;
             }
         }
 

--- a/Robot_Adapter/CRUD/Read/Results/BarResults.cs
+++ b/Robot_Adapter/CRUD/Read/Results/BarResults.cs
@@ -76,7 +76,7 @@ namespace BH.Adapter.Robot
             if (request.ObjectIds == null || request.ObjectIds.Count == 0)
                 barSelection.FromText("all");
             else
-                barSelection.FromText(Convert.ToRobotSelectionString(CheckAndGetIds(request.ObjectIds)));
+                barSelection.FromText(Convert.ToRobotSelectionString(CheckAndGetIds<Bar>(request.ObjectIds)));
 
             queryParams.Selection.Set(IRobotObjectType.I_OT_CASE, caseSelection);
             queryParams.Selection.Set(IRobotObjectType.I_OT_BAR, barSelection);
@@ -93,7 +93,29 @@ namespace BH.Adapter.Robot
 
             if (request.ResultType == BarResultType.BarDisplacement)
             {
-                bars = ReadBarsQuery(request.ObjectIds?.Select(x => x.ToString()).ToList());
+                if (request.ObjectIds == null || request.ObjectIds.Count == 0)
+                {
+                    bars = ReadBarsQuery();
+                }
+                else
+                {
+                    List<string> barIds = new List<string>();
+                    foreach (object obj in request.ObjectIds)
+                    {
+                        if (obj.GetType() == typeof(Bar))
+                        {
+                            bars.Add(obj as Bar);
+                        }
+                        else if (obj is string || obj is int || obj is double)
+                        {
+                            barIds.Add(obj.ToString());
+                        }
+                    }
+                    if (barIds.Count > 0)
+                    {
+                        bars.AddRange(ReadBarsQuery(barIds));
+                    }
+                }
             }
 
 

--- a/Robot_Adapter/CRUD/Read/Results/BarResults.cs
+++ b/Robot_Adapter/CRUD/Read/Results/BarResults.cs
@@ -99,21 +99,17 @@ namespace BH.Adapter.Robot
                 }
                 else
                 {
-                    List<string> barIds = new List<string>();
+                    List<object> barIds = new List<object>();
                     foreach (object obj in request.ObjectIds)
                     {
-                        if (obj.GetType() == typeof(Bar))
-                        {
+                        if (obj is Bar)
                             bars.Add(obj as Bar);
-                        }
-                        else if (obj is string || obj is int || obj is double)
-                        {
-                            barIds.Add(obj.ToString());
-                        }
+                        else
+                            barIds.Add(obj);
                     }
                     if (barIds.Count > 0)
                     {
-                        bars.AddRange(ReadBarsQuery(barIds));
+                        bars.AddRange(ReadBarsQuery(CheckAndGetIds<Bar>(barIds).Select(x => x.ToString()).ToList()));
                     }
                 }
             }

--- a/Robot_Adapter/CRUD/Read/Results/MeshResults.cs
+++ b/Robot_Adapter/CRUD/Read/Results/MeshResults.cs
@@ -76,21 +76,17 @@ namespace BH.Adapter.Robot
             }
             else
             {
-                List<int> panelIds = new List<int>();
+                List<object> panelIds = new List<object>();
                 foreach (object obj in request.ObjectIds)
                 {
-                    if (obj.GetType() == typeof(BH.oM.Structure.Elements.Panel))
-                    {
-                        panels.Add(obj as dynamic);
-                    }
-                    else if (obj.GetType() == typeof(string) || obj.GetType() == typeof(int))
-                    {
-                        panelIds.Add(System.Convert.ToInt32(obj));
-                    }
+                    if (obj is oM.Structure.Elements.Panel)
+                        panels.Add(obj as oM.Structure.Elements.Panel);
+                    else
+                        panelIds.Add(obj);
                 }
                 if (panelIds.Count > 0)
                 {
-                    panels.AddRange(ReadPanelsLight(panelIds as dynamic));
+                    panels.AddRange(ReadPanelsLight(CheckAndGetIds<oM.Structure.Elements.FEMesh>(panelIds)));
                 }
             }
 

--- a/Robot_Adapter/CRUD/Read/Results/NodeResults.cs
+++ b/Robot_Adapter/CRUD/Read/Results/NodeResults.cs
@@ -28,6 +28,7 @@ using BH.oM.Structure.Requests;
 using RobotOM;
 using BH.oM.Analytical.Results;
 using BH.oM.Adapter;
+using BH.oM.Structure.Elements;
 using System;
 using System.Collections;
 
@@ -70,7 +71,7 @@ namespace BH.Adapter.Robot
                     nodeSelection = m_RobotApplication.Project.Structure.Selections.CreatePredefined(IRobotPredefinedSelection.I_PS_NODE_SUPPORTED);
             }            
             else
-                nodeSelection.FromText(Convert.ToRobotSelectionString(CheckAndGetIds(request.ObjectIds)));
+                nodeSelection.FromText(Convert.ToRobotSelectionString(CheckAndGetIds<Node>(request.ObjectIds)));
 
             queryParams.Selection.Set(IRobotObjectType.I_OT_CASE, caseSelection);
             queryParams.Selection.Set(IRobotObjectType.I_OT_NODE, nodeSelection);


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #416 

 <!-- Add short description of what has been fixed -->

The CheckAndGetIds method needed to be simplified and to better handle ID filtering. Also needed to update the required pull of bars when pulling Bar Displacements, mirroring the step done for pulling Panels when extracting MeshResults.

 ### Test files
<!-- Link to test files to validate the proposed changes -->

Pulling results, filteringing ObejctIds with appropriate type of BHoMObejcts, strings/ints/doubles should all work
https://burohappold.sharepoint.com/:f:/s/BHoM/EszNjShmWNFJpiMmQ1EdM7ABAa3i7rfMe8oa54uHFtbwxg?e=ze3gZs

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->
