### PR TITLE
Remove custom data

### DIFF
--- a/Robot_Adapter/CRUD/Create/Elements/Bars.cs
+++ b/Robot_Adapter/CRUD/Create/Elements/Bars.cs
@@ -30,6 +30,8 @@ using BH.oM.Adapters.Robot;
 using BH.Engine.Structure;
 using BH.oM.Geometry;
 using BH.Engine.Geometry;
+using BH.Engine.Base;
+using BH.oM.Base;
 
 namespace BH.Adapter.Robot
 {
@@ -113,9 +115,11 @@ namespace BH.Adapter.Robot
                     if (bhomBar.Offset != null && bhomBar.Offset.Start != null && bhomBar.Offset.End != null && (bhomBar.Offset.Start.SquareLength() > 0 || bhomBar.Offset.End.SquareLength() > 0))
                         rcache.SetBarLabel(barNum, IRobotLabelType.I_LT_BAR_OFFSET, bhomBar.Offset.DescriptionOrName());
 
-                    if (bhomBar.CustomData.ContainsKey("FramingElementDesignProperties"))
+
+                    IFragment designFragment;
+                    if (bhomBar.Fragments.TryGetValue(typeof(FramingElementDesignProperties), out designFragment))
                     {
-                        FramingElementDesignProperties framEleDesProps = bhomBar.CustomData["FramingElementDesignProperties"] as FramingElementDesignProperties;
+                        FramingElementDesignProperties framEleDesProps = designFragment as FramingElementDesignProperties;
                         if (framEleDesProps != null)
                         {
                             if (m_RobotApplication.Project.Structure.Labels.Exist(IRobotLabelType.I_LT_MEMBER_TYPE, framEleDesProps.Name) != -1)

--- a/Robot_Adapter/CRUD/Create/Loads/Loadcase.cs
+++ b/Robot_Adapter/CRUD/Create/Loads/Loadcase.cs
@@ -24,6 +24,8 @@ using System.Collections.Generic;
 using System.Linq;
 using BH.oM.Structure.Loads;
 using RobotOM;
+using BH.Engine.Base;
+using BH.oM.Adapters.Robot;
 
 namespace BH.Adapter.Robot
 {
@@ -48,8 +50,9 @@ namespace BH.Adapter.Robot
                 IRobotCaseNature rNature = Convert.ToRobotLoadcaseNature(caseList[i], out subNature);
                 m_RobotApplication.Project.Structure.Cases.CreateSimple(caseList[i].Number, caseList[i].Name, rNature, IRobotCaseAnalizeType.I_CAT_STATIC_LINEAR);
                 IRobotSimpleCase sCase = caseServer.Get(caseList[i].Number) as IRobotSimpleCase;
-                object labelName;
-                sCase.label = (caseList[i].CustomData.TryGetValue("Label", out labelName) && labelName is string)? labelName as string: "";
+
+                sCase.label = caseList[i].FindFragment<LoadCaseLabel>()?.Label ?? "";
+
                 if (subNature >= 0)               
                     sCase.SetNatureExt(subNature);
             }

--- a/Robot_Adapter/CRUD/Read/Elements/Panels.cs
+++ b/Robot_Adapter/CRUD/Read/Elements/Panels.cs
@@ -33,6 +33,7 @@ using BH.oM.Structure.MaterialFragments;
 using BH.Engine.Spatial;
 using BH.Engine.Geometry;
 using BH.Engine.Structure;
+using BH.oM.Adapters.Robot;
 
 namespace BH.Adapter.Robot
 {
@@ -104,8 +105,17 @@ namespace BH.Adapter.Robot
                         continue;
                     }
                     SetAdapterId(panel, robotPanel.Number);
-                    panel.CustomData["RobotFiniteElementIds"] = robotPanel.FiniteElems;
-                    panel.CustomData["RobotNodeIds"] = robotPanel.Nodes;
+
+                    panel = Engine.Structure.Create.Panel(outline, new List<ICurve>());
+                    SetAdapterId(panel, robotPanel.Number);
+
+                    PanelFiniteElementIds feIds = new PanelFiniteElementIds
+                    {
+                        FiniteElementIds = robotPanel.FiniteElems,
+                        NodeIds = robotPanel.Nodes
+                    };
+
+                    panel.Fragments.Add(feIds);
 
                     //Get the coordinate system for the panel
                     double x, y, z; robotPanel.Main.Attribs.GetDirX(out x, out y, out z);
@@ -235,8 +245,14 @@ namespace BH.Adapter.Robot
 
                     panel = Engine.Structure.Create.Panel(outline, new List<ICurve>());
                     SetAdapterId(panel, robotPanel.Number);
-                    panel.CustomData["RobotFiniteElementIds"] = robotPanel.FiniteElems;
-                    panel.CustomData["RobotNodeIds"] = robotPanel.Nodes;
+
+                    PanelFiniteElementIds feIds = new PanelFiniteElementIds
+                    {
+                        FiniteElementIds = robotPanel.FiniteElems,
+                        NodeIds = robotPanel.Nodes
+                    };
+
+                    panel.Fragments.Add(feIds);
 
                     //Get the coordinate system for the panel
                     double x, y, z; robotPanel.Main.Attribs.GetDirX(out x, out y, out z);

--- a/Robot_Adapter/CRUD/Read/Results/MeshResults.cs
+++ b/Robot_Adapter/CRUD/Read/Results/MeshResults.cs
@@ -34,7 +34,8 @@ using BH.oM.Geometry;
 using BH.Engine.Geometry;
 using BH.oM.Adapter;
 using BH.Engine.Structure;
-using BH.oM.Base;
+using BH.Engine.Base;
+using BH.oM.Adapters.Robot;
 
 namespace BH.Adapter.Robot
 {
@@ -138,11 +139,19 @@ namespace BH.Adapter.Robot
                 RobotSelection panelSelection = robotStructureServer.Selections.Create(IRobotObjectType.I_OT_PANEL);
                 panelSelection.FromText(GetAdapterId<int>(panel).ToString());
 
+                PanelFiniteElementIds feIds = panel.FindFragment<PanelFiniteElementIds>();
+
+                if (feIds == null)
+                {
+                    Engine.Reflection.Compute.RecordWarning($"Could not access finite element ids for panel with id : { GetAdapterId<int>(panel) }. No results will be extracted for this element.");
+                    continue;
+                }
+
                 RobotSelection finiteElementSelection = robotStructureServer.Selections.Create(IRobotObjectType.I_OT_FINITE_ELEMENT);
-                finiteElementSelection.FromText(panel.CustomData["RobotFiniteElementIds"].ToString());
+                finiteElementSelection.FromText(feIds.FiniteElementIds);
 
                 RobotSelection nodeSelection = robotStructureServer.Selections.Create(IRobotObjectType.I_OT_NODE);
-                nodeSelection.FromText(panel.CustomData["RobotNodeIds"].ToString());
+                nodeSelection.FromText(feIds.NodeIds);
 
                 queryParams.Selection.Set(IRobotObjectType.I_OT_PANEL, panelSelection);
                 queryParams.Selection.Set(IRobotObjectType.I_OT_CASE, caseSelection);

--- a/Robot_Adapter/CRUD/Update/Elements/Bars.cs
+++ b/Robot_Adapter/CRUD/Update/Elements/Bars.cs
@@ -27,6 +27,8 @@ using BH.Engine.Structure;
 using BH.Engine.Geometry;
 using RobotOM;
 using BH.oM.Adapters.Robot;
+using BH.oM.Base;
+using BH.Engine.Base;
 
 namespace BH.Adapter.Robot
 {
@@ -81,9 +83,10 @@ namespace BH.Adapter.Robot
                 if (bar.Offset != null && bar.Offset.Start != null && bar.Offset.End != null && (bar.Offset.Start.SquareLength() > 0 || bar.Offset.End.SquareLength() > 0))
                     robotBar.SetLabel(IRobotLabelType.I_LT_BAR_OFFSET, bar.Offset.DescriptionOrName());
 
-                if (bar.CustomData.ContainsKey("FramingElementDesignProperties"))
+                IFragment designFragment;
+                if (bar.Fragments.TryGetValue(typeof(FramingElementDesignProperties), out designFragment))
                 {
-                    FramingElementDesignProperties framEleDesProps = bar.CustomData["FramingElementDesignProperties"] as FramingElementDesignProperties;
+                    FramingElementDesignProperties framEleDesProps = designFragment as FramingElementDesignProperties;
                     if (framEleDesProps != null)
                     {
                         if (m_RobotApplication.Project.Structure.Labels.Exist(IRobotLabelType.I_LT_MEMBER_TYPE, framEleDesProps.Name) != -1)

--- a/Robot_Adapter/Convert/FromRobot/Elements/Bar.cs
+++ b/Robot_Adapter/Convert/FromRobot/Elements/Bar.cs
@@ -131,7 +131,7 @@ namespace BH.Adapter.Robot
                 string framEleDesPropsName = robotBar.GetLabelName(IRobotLabelType.I_LT_MEMBER_TYPE);
                 if (bhomFramEleDesPropList.TryGetValue(framEleDesPropsName, out bhomFramEleDesignProps) && bhomFramEleDesignProps != null)
                 {
-                    bhomBar.CustomData["FramingElementDesignProperties"] = bhomFramEleDesignProps;
+                    bhomBar.Fragments.AddOrReplace(bhomFramEleDesignProps);
                 }
                 else
                 { 

--- a/Robot_oM/Fragments/LoadCaseLabel.cs
+++ b/Robot_oM/Fragments/LoadCaseLabel.cs
@@ -1,0 +1,36 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BH.oM.Base;
+
+namespace BH.oM.Adapters.Robot
+{
+    public class LoadCaseLabel : IFragment
+    {
+        public virtual string Label { get; set; } = "";
+    }
+}

--- a/Robot_oM/Fragments/PanelFiniteElementIds.cs
+++ b/Robot_oM/Fragments/PanelFiniteElementIds.cs
@@ -1,0 +1,39 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BH.oM.Base;
+
+
+namespace BH.oM.Adapters.Robot
+{
+    public class PanelFiniteElementIds : IFragment
+    {
+        public virtual string FiniteElementIds { get; set; } = "";
+
+        public virtual string NodeIds { get; set; } = "";
+    }
+}

--- a/Robot_oM/Robot_oM.csproj
+++ b/Robot_oM/Robot_oM.csproj
@@ -64,6 +64,7 @@
     <Compile Include="Enums\MaterialDB.cs" />
     <Compile Include="Enums\SectionDB.cs" />
     <Compile Include="Fragments\LoadCaseLabel.cs" />
+    <Compile Include="Fragments\PanelFiniteElementIds.cs" />
     <Compile Include="Fragments\RobotId.cs" />
     <Compile Include="Settings\DesignGroup.cs" />
     <Compile Include="Settings\InteractiveSettings.cs" />

--- a/Robot_oM/Robot_oM.csproj
+++ b/Robot_oM/Robot_oM.csproj
@@ -63,6 +63,7 @@
     <Compile Include="Enums\DesignCode_Steel.cs" />
     <Compile Include="Enums\MaterialDB.cs" />
     <Compile Include="Enums\SectionDB.cs" />
+    <Compile Include="Fragments\LoadCaseLabel.cs" />
     <Compile Include="Fragments\RobotId.cs" />
     <Compile Include="Settings\DesignGroup.cs" />
     <Compile Include="Settings\InteractiveSettings.cs" />

--- a/Robot_oM/Structural/Properties/FramingElementDesignProperties.cs
+++ b/Robot_oM/Structural/Properties/FramingElementDesignProperties.cs
@@ -24,7 +24,7 @@ using BH.oM.Base;
 
 namespace BH.oM.Adapters.Robot
 {
-    public class FramingElementDesignProperties : BHoMObject
+    public class FramingElementDesignProperties : BHoMObject, IFragment
     {
         /***************************************************/
         /****            Public Properties              ****/


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #426 

 <!-- Add short description of what has been fixed -->

Removing all use of Custom data in the Robot adapter, switching to use of Fragments instead.

This affects:
- FramingElementDesignProperties
- Panel FE Ids
- Loadcase label

 ### Test files
<!-- Link to test files to validate the proposed changes -->

https://burohappold.sharepoint.com/:f:/s/BHoM/El7OJUjBcChDoP3yldO0MCsB5gcD_GiuUajIwXKZVQFKbA?e=qbUYkr

https://burohappold.sharepoint.com/:f:/s/BHoM/EquJuQS0tyRNgF7YNuL5qBwBzdLgb4se7tbFNyLAODH7pQ?e=NxnECk

https://burohappold.sharepoint.com/:f:/s/BHoM/EumeCyJdngNPmHbcnctQ8GsBpZq5V-c_5jRI_zJmK4r6hw?e=7cXQZv


 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->
