### PR TITLE
Fix wrong type for some standard CHS section types

### DIFF
--- a/Robot_Adapter/Convert/FromRobot/Properties/SectionProfile_General.cs
+++ b/Robot_Adapter/Convert/FromRobot/Properties/SectionProfile_General.cs
@@ -63,7 +63,6 @@ namespace BH.Adapter.Robot
 
                     case IRobotBarSectionShapeType.I_BSST_USER_RECT:
                     case IRobotBarSectionShapeType.I_BSST_TREC:
-                    case IRobotBarSectionShapeType.I_BSST_TRON:
                     case IRobotBarSectionShapeType.I_BSST_TCAR:
                     case IRobotBarSectionShapeType.I_BSST_TRND:
                         if (r != 0)
@@ -85,6 +84,7 @@ namespace BH.Adapter.Robot
                         break;
 
                     case IRobotBarSectionShapeType.I_BSST_USER_TUBE:
+                    case IRobotBarSectionShapeType.I_BSST_TRON:
                         sectionProfile = BH.Engine.Spatial.Create.TubeProfile(d, Tf);
                         break;
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->


 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #458

 <!-- Add short description of what has been fixed -->

Updating enum previously pointing at box to be pointing to Tube


 ### Test files
<!-- Link to test files to validate the proposed changes -->

https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/Robot_Toolkit/%23459-FixCHSCatalogueSectionsPulledAsBoxProfiles?csf=1&web=1&e=wVuwrb

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->
