### PR TITLE
Robot_Adapter: Fix crash on pulling panels with hosted Beams or Columns

### DIFF
--- a/Robot_Adapter/CRUD/Read/Elements/Panels.cs
+++ b/Robot_Adapter/CRUD/Read/Elements/Panels.cs
@@ -92,8 +92,12 @@ namespace BH.Adapter.Robot
                     {
                         Opening opening;
                         RobotObjObject robotOpening = (RobotObjObject)robotOpenings.Get(j);
-                        ICurve openingOutline = Convert.IFromRobot(robotOpening.Main.GetGeometry());
 
+                        // Skipping hosted Beams and Columns - should we keep Slabs and Walls? Normal type for openings seems to be Undefined.
+                        if (robotOpening.StructuralType == IRobotObjectStructuralType.I_OST_BEAM || robotOpening.StructuralType == IRobotObjectStructuralType.I_OST_COLUMN)
+                            continue;
+
+                        ICurve openingOutline = Convert.IFromRobot(robotOpening.Main.GetGeometry());
                         if (openingOutline != null)
                             opening = BH.Engine.Structure.Create.Opening(openingOutline);
                         else


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->


 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #451 

 <!-- Add short description of what has been fixed -->
Currently, the Robot Adapter assumes that every hosted object of a panel is an Opening. This is not always the case, Panels in Robot can host other objects, such as beams. This PR fixes the crash associated with pulling panels which host beams or columns.

 ### Test files
<!-- Link to test files to validate the proposed changes -->
See linked issue for a Robot file that can not be pulled in without this fix.

 ### Additional comments
<!-- As required -->
Note that the check added by this PR only filters out hosted objects with the Structural Type of Beam or Column. The remaining types are Slab, Wall and Undefined. 

I have tested this on multiple Robot files, some pushed from the BHoM, some created in Robot. This PR does not break any of them, and none of them have openings of any type other than Undefined.

Whether Slab and Wall should also be filtered out is an issue left for later - as is whether Undefined objects could be something other than openings. Whether there are other potential crashes related to assumptions regarding hosted objects has not been investigated.
