### PR TITLE
Add Try-catch for Framing element design properties ensuring Bar pull does not crash

### DIFF
--- a/Robot_Adapter/CRUD/Read/Properties/FramingElementDesignProperties.cs
+++ b/Robot_Adapter/CRUD/Read/Properties/FramingElementDesignProperties.cs
@@ -59,53 +59,58 @@ namespace BH.Adapter.Robot
 
                 string steelMembersCodeType = m_RobotApplication.Project.Preferences.GetActiveCode(IRobotCodeType.I_CT_STEEL_STRUCTURES);
 
-                if (steelMembersCodeType == BHE.Query.GetStringFromEnum(DesignCode_Steel.BS_EN_1993_1_2005_NA_2008_A1_2014))
+                try
                 {
-                    IRDimMembParamsE32 memberDesignParams_EC3 = memberDef.CodeParams;
-                    bhomDesignProps.EulerBucklingLengthCoefficientY = memberDesignParams_EC3.BuckLengthCoeffY;
-                    bhomDesignProps.EulerBucklingLengthCoefficientZ = memberDesignParams_EC3.BuckLengthCoeffZ;
-                    //RobotEurocodeSteelDesignFactors mEuroCodeDesignFactors = rMemberType.Data;                    
-                    bool angle_conn = memberDesignParams_EC3.AngleConn;
-                    double beta = memberDesignParams_EC3.Beta;
-                    double boltsDiameter = memberDesignParams_EC3.BoltsDiam;
-                    int numberOfBolts = memberDesignParams_EC3.BoltsNo;
-                    bool isBracedInY = memberDesignParams_EC3.BracedY;
-                    bool isBracedInZ = memberDesignParams_EC3.BracedZ;
-                    IRDimBucklingCurveE32 bucklingCurveY = memberDesignParams_EC3.BucklingCurveY;
-                    IRDimBucklingCurveE32 bucklingCurveZ = memberDesignParams_EC3.BucklingCurveZ;
-                    IRDimBuckDiagramE32 bucklingDiagramY = memberDesignParams_EC3.BucklingDiagramY;
-                    IRDimBuckDiagramE32 bucklingDiagramZ = memberDesignParams_EC3.BucklingDiagramZ;
-                    IRDimComplexSectE32 complexSection = memberDesignParams_EC3.ComplexSect;
-                    double boltEdgeDistance_E2 = memberDesignParams_EC3.DistE2;
-                    double boltSpacing_P1 = memberDesignParams_EC3.DistP1;
-                    double shearParameter_ETA = memberDesignParams_EC3.Eta;
-                    IRDimFireResistE32 fireResistance = memberDesignParams_EC3.FireResist;
-                    bool isHotRolledPipe = memberDesignParams_EC3.HotRolledPipes;
-                    double kfi = memberDesignParams_EC3.Kfl;
-                    double lambda_LT0 = memberDesignParams_EC3.LamLT0;
-                    IRDimLatBuckMethodTypeE32 lateralBucklingMethodType = memberDesignParams_EC3.LatBuckMethodType;
-                    IRDimLatBuckCoeffDiagramE32 lateralBucklingCoefficientDiagram_LowerFlange = memberDesignParams_EC3.LatCoeffLowerFlange;
-                    IRDimLatBuckCoeffDiagramE32 lateralBucklingCoefficientDiagram_UpperFlange = memberDesignParams_EC3.LatCoeffUpperFlange;
-                    double lateralBucklingCoefficient_LowerFlange = memberDesignParams_EC3.LatCoeffLowerFlangeValue;
-                    double lateralBucklingCoefficient_UpperFlange = memberDesignParams_EC3.LatCoeffUpperFlangeValue;
-                    bool considerLeteralBuckling = memberDesignParams_EC3.LateralBuckling;
-                    IRDimLoadLevelE32 loadLevel = memberDesignParams_EC3.LoadLevel;
-                    double loadLevelValue = memberDesignParams_EC3.LoadLevelValue;
-                    IRDimLoadTypeE32 loadTypeY = memberDesignParams_EC3.LoadTypeY;
-                    IRDimLoadTypeE32 loadTypeZ = memberDesignParams_EC3.LoadTypeZ;
-                    double materialCoefficient_Gamma0 = memberDesignParams_EC3.MaterCoeffGamma0;
-                    double materialCoefficient_Gamma1 = memberDesignParams_EC3.MaterCoeffGamma1;
-                    double materialCoefficient_Gamma2 = memberDesignParams_EC3.MaterCoeffGamma2;
-                    double deflectionLimit_relativeY = memberDesignParams_EC3.RelLimitDeflUy;
-                    double deflectionLimit_relativeZ = memberDesignParams_EC3.RelLimitdeflUz;
-                    bool isSimplifiedParameters = memberDesignParams_EC3.Simplified;
-                    double tensileAreaNetGrossRatio = memberDesignParams_EC3.TensAreaNetGros;
-                    IRDimThinWalledE32 thinWalledProperties = memberDesignParams_EC3.ThinWalled;
-                    bool considerTorsionalBuckling = memberDesignParams_EC3.TorsBuckOn;
-                    bool tubeControl = memberDesignParams_EC3.TubeControl;
-                    IRDimYieldStrengthTypeE32 yieldStrengthType = memberDesignParams_EC3.YieldStrengthType;
-                    double yieldStrengthValue = memberDesignParams_EC3.YieldStrengthValue;
+
+                    if (steelMembersCodeType == BHE.Query.GetStringFromEnum(DesignCode_Steel.BS_EN_1993_1_2005_NA_2008_A1_2014))
+                    {
+                        IRDimMembParamsE32 memberDesignParams_EC3 = memberDef.CodeParams;
+                        bhomDesignProps.EulerBucklingLengthCoefficientY = memberDesignParams_EC3.BuckLengthCoeffY;
+                        bhomDesignProps.EulerBucklingLengthCoefficientZ = memberDesignParams_EC3.BuckLengthCoeffZ;
+                        //RobotEurocodeSteelDesignFactors mEuroCodeDesignFactors = rMemberType.Data;                    
+                        bool angle_conn = memberDesignParams_EC3.AngleConn;
+                        double beta = memberDesignParams_EC3.Beta;
+                        double boltsDiameter = memberDesignParams_EC3.BoltsDiam;
+                        int numberOfBolts = memberDesignParams_EC3.BoltsNo;
+                        bool isBracedInY = memberDesignParams_EC3.BracedY;
+                        bool isBracedInZ = memberDesignParams_EC3.BracedZ;
+                        IRDimBucklingCurveE32 bucklingCurveY = memberDesignParams_EC3.BucklingCurveY;
+                        IRDimBucklingCurveE32 bucklingCurveZ = memberDesignParams_EC3.BucklingCurveZ;
+                        IRDimBuckDiagramE32 bucklingDiagramY = memberDesignParams_EC3.BucklingDiagramY;
+                        IRDimBuckDiagramE32 bucklingDiagramZ = memberDesignParams_EC3.BucklingDiagramZ;
+                        IRDimComplexSectE32 complexSection = memberDesignParams_EC3.ComplexSect;
+                        double boltEdgeDistance_E2 = memberDesignParams_EC3.DistE2;
+                        double boltSpacing_P1 = memberDesignParams_EC3.DistP1;
+                        double shearParameter_ETA = memberDesignParams_EC3.Eta;
+                        IRDimFireResistE32 fireResistance = memberDesignParams_EC3.FireResist;
+                        bool isHotRolledPipe = memberDesignParams_EC3.HotRolledPipes;
+                        double kfi = memberDesignParams_EC3.Kfl;
+                        double lambda_LT0 = memberDesignParams_EC3.LamLT0;
+                        IRDimLatBuckMethodTypeE32 lateralBucklingMethodType = memberDesignParams_EC3.LatBuckMethodType;
+                        IRDimLatBuckCoeffDiagramE32 lateralBucklingCoefficientDiagram_LowerFlange = memberDesignParams_EC3.LatCoeffLowerFlange;
+                        IRDimLatBuckCoeffDiagramE32 lateralBucklingCoefficientDiagram_UpperFlange = memberDesignParams_EC3.LatCoeffUpperFlange;
+                        double lateralBucklingCoefficient_LowerFlange = memberDesignParams_EC3.LatCoeffLowerFlangeValue;
+                        double lateralBucklingCoefficient_UpperFlange = memberDesignParams_EC3.LatCoeffUpperFlangeValue;
+                        bool considerLeteralBuckling = memberDesignParams_EC3.LateralBuckling;
+                        IRDimLoadLevelE32 loadLevel = memberDesignParams_EC3.LoadLevel;
+                        double loadLevelValue = memberDesignParams_EC3.LoadLevelValue;
+                        IRDimLoadTypeE32 loadTypeY = memberDesignParams_EC3.LoadTypeY;
+                        IRDimLoadTypeE32 loadTypeZ = memberDesignParams_EC3.LoadTypeZ;
+                        double materialCoefficient_Gamma0 = memberDesignParams_EC3.MaterCoeffGamma0;
+                        double materialCoefficient_Gamma1 = memberDesignParams_EC3.MaterCoeffGamma1;
+                        double materialCoefficient_Gamma2 = memberDesignParams_EC3.MaterCoeffGamma2;
+                        double deflectionLimit_relativeY = memberDesignParams_EC3.RelLimitDeflUy;
+                        double deflectionLimit_relativeZ = memberDesignParams_EC3.RelLimitdeflUz;
+                        bool isSimplifiedParameters = memberDesignParams_EC3.Simplified;
+                        double tensileAreaNetGrossRatio = memberDesignParams_EC3.TensAreaNetGros;
+                        IRDimThinWalledE32 thinWalledProperties = memberDesignParams_EC3.ThinWalled;
+                        bool considerTorsionalBuckling = memberDesignParams_EC3.TorsBuckOn;
+                        bool tubeControl = memberDesignParams_EC3.TubeControl;
+                        IRDimYieldStrengthTypeE32 yieldStrengthType = memberDesignParams_EC3.YieldStrengthType;
+                        double yieldStrengthValue = memberDesignParams_EC3.YieldStrengthValue;
+                    }
                 }
+                catch { Engine.Base.Compute.RecordWarning("Failed to extract FramingElementDesignProperties"); }
 
                 if (steelMembersCodeType == BHE.Query.GetStringFromEnum(DesignCode_Steel.BS5950))
                 {

--- a/Robot_Adapter/CRUD/Read/Properties/FramingElementDesignProperties.cs
+++ b/Robot_Adapter/CRUD/Read/Properties/FramingElementDesignProperties.cs
@@ -109,48 +109,48 @@ namespace BH.Adapter.Robot
                         IRDimYieldStrengthTypeE32 yieldStrengthType = memberDesignParams_EC3.YieldStrengthType;
                         double yieldStrengthValue = memberDesignParams_EC3.YieldStrengthValue;
                     }
+
+
+                    if (steelMembersCodeType == BHE.Query.GetStringFromEnum(DesignCode_Steel.BS5950))
+                    {
+                        IRDimMembParamsBS59 memberDesignParams_BS5950 = memberDef.CodeParams;
+                        bhomDesignProps.EulerBucklingLengthCoefficientY = memberDesignParams_BS5950.BuckLengthCoeffY;
+                        bhomDesignProps.EulerBucklingLengthCoefficientZ = memberDesignParams_BS5950.BuckLengthCoeffZ;
+                    }
+
+
+                    if (steelMembersCodeType == BHE.Query.GetStringFromEnum(DesignCode_Steel.BS5950_2000))
+                    {
+                        IRDimMembParamsBS59_2000 memberDesignParams_BS5950_2000 = memberDef.CodeParams;
+                        bhomDesignProps.EulerBucklingLengthCoefficientY = memberDesignParams_BS5950_2000.BuckLengthCoeffY;
+                        bhomDesignProps.EulerBucklingLengthCoefficientZ = memberDesignParams_BS5950_2000.BuckLengthCoeffZ;
+                    }
+
+
+
+                    if (memberDef.LengthYZUV(IRDimMembDefLengthDataType.I_DMDLDT_LENGTH_Y) < 0)
+                    {
+                        bhomDesignProps.MemberLengthY = -memberDef.LengthYZUV(IRDimMembDefLengthDataType.I_DMDLDT_LENGTH_Y);
+                        bhomDesignProps.MemberLengthYIsRelative = true;
+                    }
+                    else
+                    {
+                        bhomDesignProps.MemberLengthY = memberDef.LengthYZUV(IRDimMembDefLengthDataType.I_DMDLDT_LENGTH_Y);
+                        bhomDesignProps.MemberLengthYIsRelative = false;
+                    }
+
+                    if (memberDef.LengthYZUV(IRDimMembDefLengthDataType.I_DMDLDT_LENGTH_Z) < 0)
+                    {
+                        bhomDesignProps.MemberLengthZ = -memberDef.LengthYZUV(IRDimMembDefLengthDataType.I_DMDLDT_LENGTH_Z);
+                        bhomDesignProps.MemberLengthZIsRelative = true;
+                    }
+                    else
+                    {
+                        bhomDesignProps.MemberLengthZ = memberDef.LengthYZUV(IRDimMembDefLengthDataType.I_DMDLDT_LENGTH_Z);
+                        bhomDesignProps.MemberLengthZIsRelative = false;
+                    }
                 }
                 catch { Engine.Base.Compute.RecordWarning("Failed to extract FramingElementDesignProperties"); }
-
-                if (steelMembersCodeType == BHE.Query.GetStringFromEnum(DesignCode_Steel.BS5950))
-                {
-                    IRDimMembParamsBS59 memberDesignParams_BS5950 = memberDef.CodeParams;
-                    bhomDesignProps.EulerBucklingLengthCoefficientY = memberDesignParams_BS5950.BuckLengthCoeffY;
-                    bhomDesignProps.EulerBucklingLengthCoefficientZ = memberDesignParams_BS5950.BuckLengthCoeffZ;
-                }
-
-
-                if (steelMembersCodeType == BHE.Query.GetStringFromEnum(DesignCode_Steel.BS5950_2000))
-                {
-                    IRDimMembParamsBS59_2000 memberDesignParams_BS5950_2000 = memberDef.CodeParams;
-                    bhomDesignProps.EulerBucklingLengthCoefficientY = memberDesignParams_BS5950_2000.BuckLengthCoeffY;
-                    bhomDesignProps.EulerBucklingLengthCoefficientZ = memberDesignParams_BS5950_2000.BuckLengthCoeffZ;
-                }
-
-
-
-                if (memberDef.LengthYZUV(IRDimMembDefLengthDataType.I_DMDLDT_LENGTH_Y) < 0)
-                {
-                    bhomDesignProps.MemberLengthY = -memberDef.LengthYZUV(IRDimMembDefLengthDataType.I_DMDLDT_LENGTH_Y);
-                    bhomDesignProps.MemberLengthYIsRelative = true;
-                }
-                else
-                {
-                    bhomDesignProps.MemberLengthY = memberDef.LengthYZUV(IRDimMembDefLengthDataType.I_DMDLDT_LENGTH_Y);
-                    bhomDesignProps.MemberLengthYIsRelative = false;
-                }
-
-                if (memberDef.LengthYZUV(IRDimMembDefLengthDataType.I_DMDLDT_LENGTH_Z) < 0)
-                {
-                    bhomDesignProps.MemberLengthZ = -memberDef.LengthYZUV(IRDimMembDefLengthDataType.I_DMDLDT_LENGTH_Z);
-                    bhomDesignProps.MemberLengthZIsRelative = true;
-                }
-                else
-                {
-                    bhomDesignProps.MemberLengthZ = memberDef.LengthYZUV(IRDimMembDefLengthDataType.I_DMDLDT_LENGTH_Z);
-                    bhomDesignProps.MemberLengthZIsRelative = false;
-                }
-
 
                 bhomDesignPropsList.Add(bhomDesignProps);
             }


### PR DESCRIPTION
Try catch is added around the if statement that causes the pulling method to crash in Grasshopper when pulling Robot model.

It is encouraged to review and update FramingElementDesignProperties in the future.

<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->


 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #

 <!-- Add short description of what has been fixed -->


 ### Test files
<!-- Link to test files to validate the proposed changes -->


 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->
See issue in [LINK](https://github.com/BHoM/Robot_Toolkit/issues/486)