### PR TITLE
Added comparer and AdapterID for FramingElementDesignProperties

### DIFF
--- a/Robot_Adapter/CRUD/Read/Properties/FramingElementDesignProperties.cs
+++ b/Robot_Adapter/CRUD/Read/Properties/FramingElementDesignProperties.cs
@@ -54,6 +54,7 @@ namespace BH.Adapter.Robot
                 }
 
                 FramingElementDesignProperties bhomDesignProps = BHE.Create.FramingElementDesignProperties(name);
+                SetAdapterId(bhomDesignProps, name);
 
                 double length = memberDef.Length;
 

--- a/Robot_Adapter/Types/Comparer.cs
+++ b/Robot_Adapter/Types/Comparer.cs
@@ -32,6 +32,8 @@ using BH.oM.Structure.SurfaceProperties;
 using BH.oM.Structure.Offsets;
 using System;
 using System.Collections.Generic;
+using BH.oM.Adapters.Robot;
+using BH.Engine.Base;
 
 namespace BH.Adapter.Robot
 {
@@ -55,7 +57,8 @@ namespace BH.Adapter.Robot
                 {typeof(LinkConstraint), new NameOrDescriptionComparer() },
                 {typeof(ISurfaceProperty), new NameOrDescriptionComparer() },
                 {typeof(BarRelease), new NameOrDescriptionComparer() },
-                {typeof(Offset), new NameOrDescriptionComparer() }
+                {typeof(Offset), new NameOrDescriptionComparer() },
+                {typeof(FramingElementDesignProperties), new BHoMObjectNameComparer() }
             };
         }
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->


 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #488 

 <!-- Add short description of what has been fixed -->


 ### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/Robot_Toolkit/%23489-Update-bar-with-existing-FramingElementDesignProperties?csf=1&web=1&e=qGYtAN

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->
