### PR TITLE
Correctly update Material on  Update for Bar

### DIFF
--- a/Robot_Adapter/CRUD/Update/Elements/Bars.cs
+++ b/Robot_Adapter/CRUD/Update/Elements/Bars.cs
@@ -70,9 +70,15 @@ namespace BH.Adapter.Robot
 
                 if (!string.IsNullOrWhiteSpace(bar.Name))
                     robotBar.NameTemplate = bar.Name;
-                
+
                 if (CheckNotNull(bar.SectionProperty, oM.Base.Debugging.EventType.Warning, typeof(Bar)))
+                {
                     robotBar.SetSection(bar.SectionProperty.DescriptionOrName(), false);
+
+                    if (CheckNotNull(bar.SectionProperty.Material, oM.Base.Debugging.EventType.Warning, typeof(Bar)))
+                        robotBar.SetLabel(IRobotLabelType.I_LT_MATERIAL, bar.SectionProperty.Material.DescriptionOrName());
+                }
+
 
                 robotBar.Gamma = bar.ToRobotOrientationAngle();
                 Convert.SetFEAType(robotBar, bar);


### PR DESCRIPTION
 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #513 

 <!-- Add short description of what has been fixed -->

Fixes the issue of materials not being updated on calls to Update for Bars

 ### Test files
<!-- Link to test files to validate the proposed changes -->

General Push Pull Update elements script in here:

https://burohappold.sharepoint.com/:f:/r/sites/BHoM/Installers/Scripts/Burohappold_BHoM_v6.1/Structures%20-%20Create%20-%20Read%20-%20Update%20-%20Elements?csf=1&web=1&e=Ls91Ao

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->

Good catch by @Chrisshort92 and should be fixed, but would not say critical for Beta release as bug has been here before.

If it can make the beta, great, if not we can live with the toolkit in the state without this fix.