### PR TITLE
Added error message when trying to push loadcase with a negatve or zero number assigned

### DIFF
--- a/Robot_Adapter/CRUD/Create/Loads/Loadcase.cs
+++ b/Robot_Adapter/CRUD/Create/Loads/Loadcase.cs
@@ -48,6 +48,14 @@ namespace BH.Adapter.Robot
                                 
                 int subNature;
                 IRobotCaseNature rNature = Convert.ToRobotLoadcaseNature(caseList[i], out subNature);
+
+                // Check if any loadcases havea zero
+                if(caseList.Any(lc => lc.Number == 0 || lc.Number < 1))
+                {
+                    Compute.RecordError("One or more Loadcases have a number zero (or negative number) assigned and cannot be pushed.");
+                    return false;
+                }
+
                 m_RobotApplication.Project.Structure.Cases.CreateSimple(caseList[i].Number, caseList[i].Name, rNature, IRobotCaseAnalizeType.I_CAT_STATIC_LINEAR);
                 IRobotSimpleCase sCase = caseServer.Get(caseList[i].Number) as IRobotSimpleCase;
 


### PR DESCRIPTION


<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #532 

 <!-- Add short description of what has been fixed -->


 ### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/01_Issue/BHoM/Robot_Toolkit/Issue/%23532-Loadcase%20with%20zero%20number%20not%20pushing/Loadcases%20not%20pushing.gh?csf=1&web=1&e=9eoYmv

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->
